### PR TITLE
enhance mapping for japanese searching

### DIFF
--- a/es/index_settings.json
+++ b/es/index_settings.json
@@ -4,7 +4,8 @@
 			"ja_kuromoji_index_analyzer": {
 				"type": "custom",
 				"char_filter": [
-					"normalize"
+					"normalize",
+					"kuromoji_iteration_mark"
 				],
 				"tokenizer": "ja_kuromoji_tokenizer",
 				"filter": [
@@ -13,6 +14,7 @@
 					"ja_index_synonym",
 					"cjk_width",
 					"ja_stop",
+					"kuromoji_number",
 					"kuromoji_stemmer",
 					"lowercase",
 					"ja_katakana_readingform",
@@ -22,7 +24,8 @@
 			"ja_kuromoji_search_analyzer": {
 				"type": "custom",
 				"char_filter": [
-					"normalize"
+					"normalize",
+					"kuromoji_iteration_mark"
 				],
 				"tokenizer": "ja_kuromoji_tokenizer",
 				"filter": [
@@ -31,6 +34,7 @@
 					"ja_search_synonym",
 					"cjk_width",
 					"ja_stop",
+					"kuromoji_number",
 					"kuromoji_stemmer",
 					"lowercase",
 					"ja_katakana_readingform",
@@ -40,7 +44,8 @@
 			"ja_ngram_index_analyzer": {
 				"type": "custom",
 				"char_filter": [
-					"normalize"
+					"normalize",
+					"kuromoji_iteration_mark"
 				],
 				"tokenizer": "ja_ngram_tokenizer",
 				"filter": [
@@ -52,7 +57,8 @@
 			"ja_ngram_search_analyzer": {
 				"type": "custom",
 				"char_filter": [
-					"normalize"
+					"normalize",
+					"kuromoji_iteration_mark"
 				],
 				"tokenizer": "ja_ngram_tokenizer",
 				"filter": [

--- a/es/index_settings.json
+++ b/es/index_settings.json
@@ -8,6 +8,7 @@
 				],
 				"tokenizer": "ja_kuromoji_tokenizer",
 				"filter": [
+					"ja_katakana_readingform",
 					"kuromoji_baseform",
 					"kuromoji_part_of_speech",
 					"ja_index_synonym",
@@ -24,6 +25,7 @@
 				],
 				"tokenizer": "ja_kuromoji_tokenizer",
 				"filter": [
+					"ja_katakana_readingform",
 					"kuromoji_baseform",
 					"kuromoji_part_of_speech",
 					"ja_search_synonym",
@@ -40,6 +42,7 @@
 				],
 				"tokenizer": "ja_ngram_tokenizer",
 				"filter": [
+					"ja_katakana_readingform",
 					"lowercase"
 				]
 			},
@@ -51,6 +54,7 @@
 				"tokenizer": "ja_ngram_tokenizer",
 				"filter": [
 					"ja_search_synonym",
+					"ja_katakana_readingform",
 					"lowercase"
 				]
 			},
@@ -186,6 +190,10 @@
 					"米国, アメリカ",
 					"東京大学, 東大"
 				]
+			},
+			"ja_katakana_readingform" : {
+				"type" : "kuromoji_readingform",
+				"use_romaji" : false
 			}
 		}
 	}

--- a/es/index_settings.json
+++ b/es/index_settings.json
@@ -8,14 +8,15 @@
 				],
 				"tokenizer": "ja_kuromoji_tokenizer",
 				"filter": [
-					"ja_katakana_readingform",
 					"kuromoji_baseform",
 					"kuromoji_part_of_speech",
 					"ja_index_synonym",
 					"cjk_width",
 					"ja_stop",
 					"kuromoji_stemmer",
-					"lowercase"
+					"lowercase",
+					"ja_katakana_readingform",
+					"ja_hiragana_2_katakana"
 				]
 			},
 			"ja_kuromoji_search_analyzer": {
@@ -25,14 +26,15 @@
 				],
 				"tokenizer": "ja_kuromoji_tokenizer",
 				"filter": [
-					"ja_katakana_readingform",
 					"kuromoji_baseform",
 					"kuromoji_part_of_speech",
 					"ja_search_synonym",
 					"cjk_width",
 					"ja_stop",
 					"kuromoji_stemmer",
-					"lowercase"
+					"lowercase",
+					"ja_katakana_readingform",
+					"ja_hiragana_2_katakana"
 				]
 			},
 			"ja_ngram_index_analyzer": {
@@ -42,8 +44,9 @@
 				],
 				"tokenizer": "ja_ngram_tokenizer",
 				"filter": [
+					"lowercase",
 					"ja_katakana_readingform",
-					"lowercase"
+					"ja_hiragana_2_katakana"
 				]
 			},
 			"ja_ngram_search_analyzer": {
@@ -54,8 +57,9 @@
 				"tokenizer": "ja_ngram_tokenizer",
 				"filter": [
 					"ja_search_synonym",
+					"lowercase",
 					"ja_katakana_readingform",
-					"lowercase"
+					"ja_hiragana_2_katakana"
 				]
 			},
 			"index_ngram": {
@@ -162,7 +166,7 @@
 			},
 			"normalize": {
 				"type": "icu_normalizer",
-				"name": "nfkc",
+				"name": "nfkc_cf",
 				"mode": "compose"
 			}
 		},
@@ -194,6 +198,10 @@
 			"ja_katakana_readingform" : {
 				"type" : "kuromoji_readingform",
 				"use_romaji" : false
+			},
+			"ja_hiragana_2_katakana": {  
+				"type": "icu_transform",
+				"id": "Hiragana-Katakana"
 			}
 		}
 	}

--- a/es/index_settings.json
+++ b/es/index_settings.json
@@ -17,7 +17,6 @@
 					"kuromoji_number",
 					"kuromoji_stemmer",
 					"lowercase",
-					"ja_katakana_readingform",
 					"ja_hiragana_2_katakana"
 				]
 			},
@@ -37,7 +36,6 @@
 					"kuromoji_number",
 					"kuromoji_stemmer",
 					"lowercase",
-					"ja_katakana_readingform",
 					"ja_hiragana_2_katakana"
 				]
 			},
@@ -50,7 +48,6 @@
 				"tokenizer": "ja_ngram_tokenizer",
 				"filter": [
 					"lowercase",
-					"ja_katakana_readingform",
 					"ja_hiragana_2_katakana"
 				]
 			},
@@ -64,7 +61,6 @@
 				"filter": [
 					"ja_search_synonym",
 					"lowercase",
-					"ja_katakana_readingform",
 					"ja_hiragana_2_katakana"
 				]
 			},

--- a/es/mappings.json
+++ b/es/mappings.json
@@ -58,7 +58,7 @@
 						"type": "text",
 						"index": false,
 						"copy_to": [
-							"collector.ja_kana"
+							"collector.ja"
 						]
 					}
 				}
@@ -91,7 +91,10 @@
 								"type": "text",
 								"analyzer": "index_raw"
 							}
-						}
+						},
+						"copy_to": [
+							"collector.ja"
+						]
 					},
 					"en": {
 						"type": "text",
@@ -149,7 +152,7 @@
 					},
 					"ja": {
 						"type": "text",
-						"index": false,
+						"index": true,
 						"fields": {
 							"ngrams": {
 								"type": "text",
@@ -160,28 +163,7 @@
 								"type": "text",
 								"analyzer": "ja_kuromoji_index_analyzer"
 							}
-						},
-						"copy_to": [
-							"collector.ja"
-						]
-					},
-					"ja_kana": {
-						"type": "text",
-						"index": false,
-						"fields": {
-							"ngrams": {
-								"type": "text",
-								"analyzer": "ja_ngram_index_analyzer",
-								"search_analyzer": "ja_ngram_search_analyzer"
-							},
-							"raw": {
-								"type": "text",
-								"analyzer": "ja_kuromoji_index_analyzer"
-							}
-						},
-						"copy_to": [
-							"collector.ja_kana"
-						]
+						}
 					}
 				}
 			},
@@ -233,7 +215,7 @@
 						"type": "text",
 						"index": false,
 						"copy_to": [
-							"collector.ja_kana"
+							"collector.ja"
 						]
 					}
 				}
@@ -289,7 +271,7 @@
 						"type": "text",
 						"index": false,
 						"copy_to": [
-							"collector.ja_kana"
+							"collector.ja"
 						]
 					}
 				}
@@ -456,7 +438,7 @@
 							}
 						},
 						"copy_to": [
-							"collector.ja_kana"
+							"collector.ja"
 						]
 					},
 					"loc": {
@@ -587,7 +569,7 @@
 						"type": "text",
 						"index": false,
 						"copy_to": [
-							"collector.ja_kana"
+							"collector.ja"
 						]
 					}
 				}
@@ -640,7 +622,7 @@
 						"type": "text",
 						"index": false,
 						"copy_to": [
-							"collector.ja_kana"
+							"collector.ja"
 						]
 					}
 				}
@@ -693,7 +675,7 @@
 						"type": "text",
 						"index": false,
 						"copy_to": [
-							"collector.ja_kana"
+							"collector.ja"
 						]
 					}
 				}
@@ -746,7 +728,7 @@
 						"type": "text",
 						"index": false,
 						"copy_to": [
-							"collector.ja_kana"
+							"collector.ja"
 						]
 					}
 				}
@@ -799,7 +781,7 @@
 						"type": "text",
 						"index": false,
 						"copy_to": [
-							"collector.ja_kana"
+							"collector.ja"
 						]
 					}
 				}

--- a/es/mappings.json
+++ b/es/mappings.json
@@ -85,11 +85,15 @@
 					},
 					"default": {
 						"type": "text",
-						"analyzer": "index_ngram",
 						"fields": {
+							"ngrams": {
+								"type": "text",
+								"analyzer": "ja_ngram_index_analyzer",
+								"search_analyzer": "ja_ngram_search_analyzer"
+							},
 							"raw": {
 								"type": "text",
-								"analyzer": "index_raw"
+								"analyzer": "ja_kuromoji_index_analyzer"
 							}
 						},
 						"copy_to": [

--- a/src/main/java/de/komoot/photon/query/PhotonQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/query/PhotonQueryBuilder.java
@@ -4,6 +4,7 @@ package de.komoot.photon.query;
 import com.google.common.collect.ImmutableSet;
 import com.vividsolutions.jts.geom.Envelope;
 import com.vividsolutions.jts.geom.Point;
+import java.util.*;
 import org.elasticsearch.common.lucene.search.function.CombineFunction;
 import org.elasticsearch.common.lucene.search.function.FiltersFunctionScoreQuery.ScoreMode;
 import org.elasticsearch.common.unit.Fuzziness;
@@ -15,7 +16,6 @@ import org.elasticsearch.index.query.functionscore.ScriptScoreFunctionBuilder;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptType;
 
-import java.util.*;
 
 import static com.google.common.collect.Maps.newHashMap;
 
@@ -57,6 +57,16 @@ public class PhotonQueryBuilder {
         query4QueryBuilder = QueryBuilders.boolQuery();
 
         if (lenient) {
+            Fuzziness fizziness = Fuzziness.ONE;
+            String analyzer = "search_ngram";
+            ArrayList<String> target_lang = new ArrayList<String>();
+            target_lang.add("ja");
+            target_lang.add("ja_kana");
+            
+            if (target_lang.contains(language)){
+                fizziness = Fuzziness.TWO;
+                analyzer = "ja_ngram_search_analyzer";
+            }
             BoolQueryBuilder builder = QueryBuilders.boolQuery()
                     .should(QueryBuilders.matchQuery("collector.default", query)
                                 .fuzziness(Fuzziness.ONE)
@@ -64,9 +74,9 @@ public class PhotonQueryBuilder {
                                 .analyzer("search_ngram")
                                 .minimumShouldMatch("-1"))
                     .should(QueryBuilders.matchQuery(String.format("collector.%s.ngrams", language), query)
-                                .fuzziness(Fuzziness.ONE)
+                                .fuzziness(fizziness)
                                 .prefixLength(2)
-                                .analyzer("search_ngram")
+                                .analyzer(analyzer)
                                 .minimumShouldMatch("-1"))
                     .minimumShouldMatch("1");
 

--- a/src/main/java/de/komoot/photon/query/PhotonQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/query/PhotonQueryBuilder.java
@@ -57,24 +57,21 @@ public class PhotonQueryBuilder {
         query4QueryBuilder = QueryBuilders.boolQuery();
 
         if (lenient) {
-            Fuzziness fizziness = Fuzziness.ONE;
+            Fuzziness fuzziness = Fuzziness.ONE;
             String analyzer = "search_ngram";
-            ArrayList<String> target_lang = new ArrayList<String>();
-            target_lang.add("ja");
-            target_lang.add("ja_kana");
-            
-            if (target_lang.contains(language)){
-                fizziness = Fuzziness.TWO;
+            ArrayList<String> ja_languages = new ArrayList<String>(Arrays.asList("ja", "ja_kana"));            
+            if (ja_languages.contains(language)){
+                fuzziness = Fuzziness.TWO;
                 analyzer = "ja_ngram_search_analyzer";
             }
             BoolQueryBuilder builder = QueryBuilders.boolQuery()
                     .should(QueryBuilders.matchQuery("collector.default", query)
-                                .fuzziness(Fuzziness.ONE)
+                                .fuzziness(fuzziness)
                                 .prefixLength(2)
-                                .analyzer("search_ngram")
+                                .analyzer(analyzer)
                                 .minimumShouldMatch("-1"))
                     .should(QueryBuilders.matchQuery(String.format("collector.%s.ngrams", language), query)
-                                .fuzziness(fizziness)
+                                .fuzziness(fuzziness)
                                 .prefixLength(2)
                                 .analyzer(analyzer)
                                 .minimumShouldMatch("-1"))

--- a/src/main/java/de/komoot/photon/query/PhotonQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/query/PhotonQueryBuilder.java
@@ -61,7 +61,7 @@ public class PhotonQueryBuilder {
             String analyzer = "search_ngram";
             ArrayList<String> ja_languages = new ArrayList<String>(Arrays.asList("ja", "ja_kana"));            
             if (ja_languages.contains(language)){
-                fuzziness = Fuzziness.TWO;
+                fuzziness = Fuzziness.AUTO;
                 analyzer = "ja_ngram_search_analyzer";
             }
             BoolQueryBuilder builder = QueryBuilders.boolQuery()

--- a/src/main/java/de/komoot/photon/query/PhotonQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/query/PhotonQueryBuilder.java
@@ -61,7 +61,7 @@ public class PhotonQueryBuilder {
             String analyzer = "search_ngram";
             ArrayList<String> ja_languages = new ArrayList<String>(Arrays.asList("ja", "ja_kana"));            
             if (ja_languages.contains(language)){
-                fuzziness = Fuzziness.TWO;
+                fuzziness = Fuzziness.ONE;
                 analyzer = "ja_ngram_search_analyzer";
             }
             BoolQueryBuilder builder = QueryBuilders.boolQuery()

--- a/src/main/java/de/komoot/photon/query/PhotonQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/query/PhotonQueryBuilder.java
@@ -61,7 +61,7 @@ public class PhotonQueryBuilder {
             String analyzer = "search_ngram";
             ArrayList<String> ja_languages = new ArrayList<String>(Arrays.asList("ja", "ja_kana"));            
             if (ja_languages.contains(language)){
-                fuzziness = Fuzziness.AUTO;
+                fuzziness = Fuzziness.TWO;
                 analyzer = "ja_ngram_search_analyzer";
             }
             BoolQueryBuilder builder = QueryBuilders.boolQuery()


### PR DESCRIPTION
- adopt japanese analyzer for photonquerybuilder
- ja_kana will be copied to collector.ja
- collector.default will use kuromoji analyzer because some Japanese label exists in `name` tag.
- collector.default will be copied to collector.ja