### PR TITLE
reverted PhotonQueryBuilder as original

### DIFF
--- a/src/main/java/de/komoot/photon/query/PhotonQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/query/PhotonQueryBuilder.java
@@ -57,23 +57,16 @@ public class PhotonQueryBuilder {
         query4QueryBuilder = QueryBuilders.boolQuery();
 
         if (lenient) {
-            Fuzziness fuzziness = Fuzziness.ONE;
-            String analyzer = "search_ngram";
-            ArrayList<String> ja_languages = new ArrayList<String>(Arrays.asList("ja", "ja_kana"));            
-            if (ja_languages.contains(language)){
-                fuzziness = Fuzziness.ONE;
-                analyzer = "ja_ngram_search_analyzer";
-            }
             BoolQueryBuilder builder = QueryBuilders.boolQuery()
                     .should(QueryBuilders.matchQuery("collector.default", query)
-                                .fuzziness(fuzziness)
+                                .fuzziness(Fuzziness.ONE)
                                 .prefixLength(2)
-                                .analyzer(analyzer)
+                                .analyzer("search_ngram")
                                 .minimumShouldMatch("-1"))
                     .should(QueryBuilders.matchQuery(String.format("collector.%s.ngrams", language), query)
-                                .fuzziness(fuzziness)
+                                .fuzziness(Fuzziness.ONE)
                                 .prefixLength(2)
-                                .analyzer(analyzer)
+                                .analyzer("search_ngram")
                                 .minimumShouldMatch("-1"))
                     .minimumShouldMatch("1");
 


### PR DESCRIPTION
- I reverted photonquerybuilder's change as original one.

I did setup in the following URL after reverting, and I think there is no problem for Japanese searching...

```
http://35.200.102.215:2322/api?q=
```