### PR TITLE
changed termquery to wildcardquery in photonquerybuilder

### DIFF
--- a/src/main/java/de/komoot/photon/query/PhotonQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/query/PhotonQueryBuilder.java
@@ -92,8 +92,8 @@ public class PhotonQueryBuilder {
                         .analyzer(analyzer))
                 .should(QueryBuilders.matchQuery(String.format("collector.%s.raw", language), query).boost(100)
                         .analyzer(analyzer))
-                .should(QueryBuilders.termQuery(String.format("name.%s.keyword", language), query).boost(400))
-                .should(QueryBuilders.termQuery(String.format("collector.%s.keyword", language), query).boost(300));
+                .should(QueryBuilders.wildcardQuery(String.format("name.%s.keyword", language), String.format("*%s*", query)).boost(400))
+                .should(QueryBuilders.wildcardQuery(String.format("collector.%s.keyword", language), String.format("*%s*", query)).boost(300));
 
         // this is former general-score, now inline
         String strCode = "double score = 1 + doc['importance'].value * 100; score";

--- a/src/test/resources/json_queries/test_base_query.json
+++ b/src/test/resources/json_queries/test_base_query.json
@@ -83,17 +83,17 @@
 									}
 								},
 								{
-									"term": {
+									"wildcard": {
 										"name.en.keyword": {
-											"value": "berlin",
+											"wildcard": "*berlin*",
 											"boost": 400.0
 										}
 									}
 								},
 								{
-									"term": {
+									"wildcard": {
 										"collector.en.keyword": {
-											"value": "berlin",
+											"wildcard": "*berlin*",
 											"boost": 300.0
 										}
 									}

--- a/src/test/resources/json_queries/test_base_query_fr.json
+++ b/src/test/resources/json_queries/test_base_query_fr.json
@@ -83,17 +83,17 @@
 									}
 								},
 								{
-									"term": {
+									"wildcard": {
 										"name.fr.keyword": {
-											"value": "berlin",
+											"wildcard": "*berlin*",
 											"boost": 400.0
 										}
 									}
 								},
 								{
-									"term": {
+									"wildcard": {
 										"collector.fr.keyword": {
-											"value": "berlin",
+											"wildcard": "*berlin*",
 											"boost": 300.0
 										}
 									}

--- a/src/test/resources/json_queries/test_base_query_ja.json
+++ b/src/test/resources/json_queries/test_base_query_ja.json
@@ -83,17 +83,17 @@
 									}
 								},
 								{
-									"term": {
+									"wildcard": {
 										"name.ja.keyword": {
-											"value": "berlin",
+											"wildcard": "*berlin*",
 											"boost": 400.0
 										}
 									}
 								},
 								{
-									"term": {
+									"wildcard": {
 										"collector.ja.keyword": {
-											"value": "berlin",
+											"wildcard": "*berlin*",
 											"boost": 300.0
 										}
 									}


### PR DESCRIPTION
- to use wildcardQuery in PhotonQueryBuilder instead of termQuery in order to match more result than term.