### PR TITLE
separate analyzers for collector.default and collector.ja

### DIFF
--- a/es/index_settings.json
+++ b/es/index_settings.json
@@ -1,6 +1,56 @@
 {
 	"analysis": {
 		"analyzer": {
+			"default_index_raw": {
+				"type": "custom",
+				"char_filter": [
+					"punctuationgreedy",
+					"ja_normalize"
+				],
+				"tokenizer": "default_kuromoji_tokenizer",
+				"filter": [
+					"word_delimiter",
+					"lowercase",
+					"german_normalization",
+					"asciifolding",
+					"unique",
+					"kuromoji_baseform",
+					"kuromoji_part_of_speech",
+					"cjk_width",
+					"ja_stop",
+					"kuromoji_number",
+					"kuromoji_stemmer"
+				]
+			},
+			"default_index_ngram": {
+				"type": "custom",
+				"char_filter": [
+					"punctuationgreedy",
+					"remove_ws_hnr_suffix",
+					"ja_normalize"
+				],
+				"tokenizer": "edge_ngram",
+				"filter": [
+					"preserving_word_delimiter",
+					"lowercase",
+					"german_normalization",
+					"asciifolding",
+					"unique"
+				]
+			},
+			"default_search_ngram": {
+				"type": "custom",
+				"char_filter": [
+					"punctuationgreedy",
+					"ja_normalize"
+				],
+				"tokenizer": "edge_ngram",
+				"filter": [
+					"lowercase",
+					"german_normalization",
+					"asciifolding"
+				]
+			},
 			"ja_index_raw": {
 				"type": "custom",
 				"char_filter": [
@@ -132,6 +182,13 @@
 				"token_chars": [
 					"letter",
 					"digit"
+				]
+			},
+			"default_kuromoji_tokenizer": {
+				"mode": "normal",
+				"type": "kuromoji_tokenizer",
+				"discard_compound_token": true,
+				"user_dictionary_rules": [
 				]
 			},
 			"ja_kuromoji_tokenizer": {

--- a/es/mappings.json
+++ b/es/mappings.json
@@ -78,15 +78,11 @@
 					},
 					"default": {
 						"type": "text",
+						"analyzer": "default_index_ngram",
 						"fields": {
-							"ngrams": {
-								"type": "text",
-								"analyzer": "ja_index_ngram",
-								"search_analyzer": "ja_search_ngram"
-							},
 							"raw": {
 								"type": "text",
-								"analyzer": "ja_index_raw"
+								"analyzer": "default_index_raw"
 							}
 						}
 					},

--- a/src/main/java/de/komoot/photon/query/PhotonQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/query/PhotonQueryBuilder.java
@@ -72,7 +72,7 @@ public class PhotonQueryBuilder {
                     .should(QueryBuilders.matchQuery("collector.default", query)
                                 .fuzziness(Fuzziness.ONE)
                                 .prefixLength(2)
-                                .analyzer("search_ngram")
+                                .analyzer("default_search_ngram")
                                 .minimumShouldMatch("-1"))
                     .should(QueryBuilders.matchQuery(String.format("collector.%s.ngrams", language), query)
                                 .fuzziness(Fuzziness.ONE)
@@ -84,7 +84,7 @@ public class PhotonQueryBuilder {
             query4QueryBuilder.must(builder);
         } else {
             MultiMatchQueryBuilder builder =
-                    QueryBuilders.multiMatchQuery(query).field("collector.default", 1.0f).type(MultiMatchQueryBuilder.Type.CROSS_FIELDS).prefixLength(2).analyzer("search_ngram").minimumShouldMatch("100%");
+                    QueryBuilders.multiMatchQuery(query).field("collector.default", 1.0f).type(MultiMatchQueryBuilder.Type.CROSS_FIELDS).prefixLength(2).analyzer("default_search_ngram").minimumShouldMatch("100%");
 
             for (String lang : languages) {
                 builder.field(String.format("collector.%s.ngrams", lang), lang.equals(language) ? 1.0f : 0.6f);

--- a/src/test/resources/json_queries/test_base_query.json
+++ b/src/test/resources/json_queries/test_base_query.json
@@ -14,7 +14,7 @@
 													"collector.default": {
 														"query": "berlin",
 														"operator": "OR",
-														"analyzer": "search_ngram",
+														"analyzer": "default_search_ngram",
 														"fuzziness": "1",
 														"prefix_length": 2,
 														"max_expansions": 50,

--- a/src/test/resources/json_queries/test_base_query_fr.json
+++ b/src/test/resources/json_queries/test_base_query_fr.json
@@ -14,7 +14,7 @@
 													"collector.default": {
 														"query": "berlin",
 														"operator": "OR",
-														"analyzer": "search_ngram",
+														"analyzer": "default_search_ngram",
 														"fuzziness": "1",
 														"prefix_length": 2,
 														"max_expansions": 50,

--- a/src/test/resources/json_queries/test_base_query_ja.json
+++ b/src/test/resources/json_queries/test_base_query_ja.json
@@ -14,7 +14,7 @@
 													"collector.default": {
 														"query": "berlin",
 														"operator": "OR",
-														"analyzer": "search_ngram",
+														"analyzer": "default_search_ngram",
 														"fuzziness": "1",
 														"prefix_length": 2,
 														"max_expansions": 50,


### PR DESCRIPTION
I suspect ja analyzer which is used for collector.default affect other languages' searching. However, it is very necessary to use kuromoji for collector.default in order to index Japanese text in `name`. Thus, I added analyzer for collector.default instead of using ja analyzer. I mixed some filters both ja and original ones into new default analyzer.

let's see how it works after creating index...

reference:
- https://kazu.tv/blog/2016/11/07/i18n-elasticsearch-part-1/
- https://www.elastic.co/jp/blog/implementing-japanese-autocomplete-suggestions-in-elasticsearch