### PR TITLE
optimized collector.default analyzer

### DIFF
--- a/es/mappings.json
+++ b/es/mappings.json
@@ -78,12 +78,8 @@
 					},
 					"default": {
 						"type": "text",
+						"analyzer": "index_ngram",
 						"fields": {
-							"ngrams": {
-								"type": "text",
-								"analyzer": "ja_index_ngram",
-								"search_analyzer": "ja_search_ngram"
-							},
 							"raw": {
 								"type": "text",
 								"analyzer": "ja_index_raw"


### PR DESCRIPTION
original photon's default analyzer does not have `search_ngram`, so I deleted it.

also, I changed from `ja_index_ngram` to `index_ngram` in order to match the analyzer in `PhotonQueryBuilder`'s `search_ngram`.

Because `ja_index_raw` still remains, I hope it can be better to index Japanese text.