### PR TITLE
added ja_ngrams and ja_raw into collector.default

### DIFF
--- a/es/index_settings.json
+++ b/es/index_settings.json
@@ -1,56 +1,6 @@
 {
 	"analysis": {
 		"analyzer": {
-			"default_index_raw": {
-				"type": "custom",
-				"char_filter": [
-					"punctuationgreedy",
-					"ja_normalize"
-				],
-				"tokenizer": "default_kuromoji_tokenizer",
-				"filter": [
-					"word_delimiter",
-					"lowercase",
-					"german_normalization",
-					"asciifolding",
-					"unique",
-					"kuromoji_baseform",
-					"kuromoji_part_of_speech",
-					"cjk_width",
-					"ja_stop",
-					"kuromoji_number",
-					"kuromoji_stemmer"
-				]
-			},
-			"default_index_ngram": {
-				"type": "custom",
-				"char_filter": [
-					"punctuationgreedy",
-					"remove_ws_hnr_suffix",
-					"ja_normalize"
-				],
-				"tokenizer": "edge_ngram",
-				"filter": [
-					"preserving_word_delimiter",
-					"lowercase",
-					"german_normalization",
-					"asciifolding",
-					"unique"
-				]
-			},
-			"default_search_ngram": {
-				"type": "custom",
-				"char_filter": [
-					"punctuationgreedy",
-					"ja_normalize"
-				],
-				"tokenizer": "edge_ngram",
-				"filter": [
-					"lowercase",
-					"german_normalization",
-					"asciifolding"
-				]
-			},
 			"ja_index_raw": {
 				"type": "custom",
 				"char_filter": [
@@ -182,13 +132,6 @@
 				"token_chars": [
 					"letter",
 					"digit"
-				]
-			},
-			"default_kuromoji_tokenizer": {
-				"mode": "normal",
-				"type": "kuromoji_tokenizer",
-				"discard_compound_token": true,
-				"user_dictionary_rules": [
 				]
 			},
 			"ja_kuromoji_tokenizer": {

--- a/es/mappings.json
+++ b/es/mappings.json
@@ -78,11 +78,25 @@
 					},
 					"default": {
 						"type": "text",
-						"analyzer": "default_index_ngram",
+						"index": false,
 						"fields": {
+							"ngrams": {
+								"type": "text",
+								"analyzer": "index_ngram",
+								"search_analyzer": "search_ngram"
+							},
 							"raw": {
 								"type": "text",
-								"analyzer": "default_index_raw"
+								"analyzer": "index_raw"
+							},
+							"ja_ngrams": {
+								"type": "text",
+								"analyzer": "ja_index_ngram",
+								"search_analyzer": "ja_search_ngram"
+							},
+							"ja_raw": {
+								"type": "text",
+								"analyzer": "ja_index_raw"
 							}
 						}
 					},

--- a/src/main/java/de/komoot/photon/query/PhotonQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/query/PhotonQueryBuilder.java
@@ -68,34 +68,45 @@ public class PhotonQueryBuilder {
         }
 
         if (lenient) {
-            BoolQueryBuilder builder = QueryBuilders.boolQuery()
-                    .should(QueryBuilders.matchQuery("collector.default.ngrams", query)
-                            .fuzziness(Fuzziness.ONE)
-                            .prefixLength(2)
-                            .analyzer("search_ngram")
-                            .minimumShouldMatch("-1"));
+            BoolQueryBuilder builder;
 
-            switch (language){
+            switch (language) {
                 case "ja":
-                    builder = builder
+                    builder = QueryBuilders.boolQuery()
+                            .should(QueryBuilders.matchQuery("collector.default.ngrams", query)
+                                    .fuzziness(Fuzziness.ONE)
+                                    .prefixLength(2)
+                                    .analyzer("search_ngram")
+                                    .minimumShouldMatch("-1"))
                             .should(QueryBuilders.matchQuery(String.format("collector.default.ja_ngrams", language), query)
+                                    .fuzziness(Fuzziness.ONE)
+                                    .prefixLength(2)
+                                    .analyzer(ngramAnalyzer)
+                                    .fuzzyTranspositions(false)
+                                    .minimumShouldMatch("-1"))
+                            .should(QueryBuilders.matchQuery(String.format("collector.%s.ngrams", language), query)
+                                    .fuzziness(Fuzziness.ONE)
+                                    .prefixLength(2)
+                                    .analyzer(ngramAnalyzer)
+                                    .fuzzyTranspositions(false)
+                                    .minimumShouldMatch("-1"))
+                            .minimumShouldMatch("1");
+                    break;
+                default:
+                    builder = QueryBuilders.boolQuery()
+                            .should(QueryBuilders.matchQuery("collector.default.ngrams", query)
+                                    .fuzziness(Fuzziness.ONE)
+                                    .prefixLength(2)
+                                    .analyzer("search_ngram")
+                                    .minimumShouldMatch("-1"))
+                            .should(QueryBuilders.matchQuery(String.format("collector.%s.ngrams", language), query)
                                     .fuzziness(Fuzziness.ONE)
                                     .prefixLength(2)
                                     .analyzer(ngramAnalyzer)
                                     .minimumShouldMatch("-1"))
                             .minimumShouldMatch("1");
                     break;
-                default:
-                    break;
             }
-
-            builder = builder
-                    .should(QueryBuilders.matchQuery(String.format("collector.%s.ngrams", language), query)
-                                .fuzziness(Fuzziness.ONE)
-                                .prefixLength(2)
-                                .analyzer(ngramAnalyzer)
-                                .minimumShouldMatch("-1"))
-                    .minimumShouldMatch("1");
 
             query4QueryBuilder.must(builder);
         } else {

--- a/src/main/java/de/komoot/photon/query/PhotonQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/query/PhotonQueryBuilder.java
@@ -73,12 +73,7 @@ public class PhotonQueryBuilder {
             switch (language) {
                 case "ja":
                     builder = QueryBuilders.boolQuery()
-                            .should(QueryBuilders.matchQuery("collector.default.ngrams", query)
-                                    .fuzziness(Fuzziness.ONE)
-                                    .prefixLength(2)
-                                    .analyzer("search_ngram")
-                                    .minimumShouldMatch("-1"))
-                            .should(QueryBuilders.matchQuery(String.format("collector.default.ja_ngrams", language), query)
+                            .should(QueryBuilders.matchQuery("collector.default.ja_ngrams", query)
                                     .fuzziness(Fuzziness.ONE)
                                     .prefixLength(2)
                                     .analyzer(ngramAnalyzer)

--- a/src/main/java/de/komoot/photon/query/PhotonQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/query/PhotonQueryBuilder.java
@@ -69,11 +69,27 @@ public class PhotonQueryBuilder {
 
         if (lenient) {
             BoolQueryBuilder builder = QueryBuilders.boolQuery()
-                    .should(QueryBuilders.matchQuery("collector.default", query)
-                                .fuzziness(Fuzziness.ONE)
-                                .prefixLength(2)
-                                .analyzer("default_search_ngram")
-                                .minimumShouldMatch("-1"))
+                    .should(QueryBuilders.matchQuery("collector.default.ngrams", query)
+                            .fuzziness(Fuzziness.ONE)
+                            .prefixLength(2)
+                            .analyzer("search_ngram")
+                            .minimumShouldMatch("-1"));
+
+            switch (language){
+                case "ja":
+                    builder = builder
+                            .should(QueryBuilders.matchQuery(String.format("collector.default.ja_ngrams", language), query)
+                                    .fuzziness(Fuzziness.ONE)
+                                    .prefixLength(2)
+                                    .analyzer(ngramAnalyzer)
+                                    .minimumShouldMatch("-1"))
+                            .minimumShouldMatch("1");
+                    break;
+                default:
+                    break;
+            }
+
+            builder = builder
                     .should(QueryBuilders.matchQuery(String.format("collector.%s.ngrams", language), query)
                                 .fuzziness(Fuzziness.ONE)
                                 .prefixLength(2)
@@ -84,7 +100,7 @@ public class PhotonQueryBuilder {
             query4QueryBuilder.must(builder);
         } else {
             MultiMatchQueryBuilder builder =
-                    QueryBuilders.multiMatchQuery(query).field("collector.default", 1.0f).type(MultiMatchQueryBuilder.Type.CROSS_FIELDS).prefixLength(2).analyzer("default_search_ngram").minimumShouldMatch("100%");
+                    QueryBuilders.multiMatchQuery(query).field("collector.default.ngrams", 1.0f).type(MultiMatchQueryBuilder.Type.CROSS_FIELDS).prefixLength(2).analyzer("search_ngram").minimumShouldMatch("100%");
 
             for (String lang : languages) {
                 builder.field(String.format("collector.%s.ngrams", lang), lang.equals(language) ? 1.0f : 0.6f);

--- a/src/test/resources/json_queries/test_base_query.json
+++ b/src/test/resources/json_queries/test_base_query.json
@@ -11,10 +11,10 @@
 										"should": [
 											{
 												"match": {
-													"collector.default": {
+													"collector.default.ngrams": {
 														"query": "berlin",
 														"operator": "OR",
-														"analyzer": "default_search_ngram",
+														"analyzer": "search_ngram",
 														"fuzziness": "1",
 														"prefix_length": 2,
 														"max_expansions": 50,

--- a/src/test/resources/json_queries/test_base_query_fr.json
+++ b/src/test/resources/json_queries/test_base_query_fr.json
@@ -11,10 +11,10 @@
 										"should": [
 											{
 												"match": {
-													"collector.default": {
+													"collector.default.ngrams": {
 														"query": "berlin",
 														"operator": "OR",
-														"analyzer": "default_search_ngram",
+														"analyzer": "search_ngram",
 														"fuzziness": "1",
 														"prefix_length": 2,
 														"max_expansions": 50,

--- a/src/test/resources/json_queries/test_base_query_ja.json
+++ b/src/test/resources/json_queries/test_base_query_ja.json
@@ -11,23 +11,6 @@
 										"should": [
 											{
 												"match": {
-													"collector.default.ngrams": {
-														"query": "berlin",
-														"operator": "OR",
-														"analyzer": "search_ngram",
-														"fuzziness": "1",
-														"prefix_length": 2,
-														"max_expansions": 50,
-														"minimum_should_match": "-1",
-														"fuzzy_transpositions": true,
-														"lenient": false,
-														"zero_terms_query": "NONE",
-														"boost": 1.0
-													}
-												}
-											},
-											{
-												"match": {
 													"collector.default.ja_ngrams": {
 														"query": "berlin",
 														"operator": "OR",

--- a/src/test/resources/json_queries/test_base_query_ja.json
+++ b/src/test/resources/json_queries/test_base_query_ja.json
@@ -36,7 +36,7 @@
 														"prefix_length": 2,
 														"max_expansions": 50,
 														"minimum_should_match": "-1",
-														"fuzzy_transpositions": true,
+														"fuzzy_transpositions": false,
 														"lenient": false,
 														"zero_terms_query": "NONE",
 														"boost": 1.0
@@ -53,7 +53,7 @@
 														"prefix_length": 2,
 														"max_expansions": 50,
 														"minimum_should_match": "-1",
-														"fuzzy_transpositions": true,
+														"fuzzy_transpositions": false,
 														"lenient": false,
 														"zero_terms_query": "NONE",
 														"boost": 1.0

--- a/src/test/resources/json_queries/test_base_query_ja.json
+++ b/src/test/resources/json_queries/test_base_query_ja.json
@@ -11,10 +11,27 @@
 										"should": [
 											{
 												"match": {
-													"collector.default": {
+													"collector.default.ngrams": {
 														"query": "berlin",
 														"operator": "OR",
-														"analyzer": "default_search_ngram",
+														"analyzer": "search_ngram",
+														"fuzziness": "1",
+														"prefix_length": 2,
+														"max_expansions": 50,
+														"minimum_should_match": "-1",
+														"fuzzy_transpositions": true,
+														"lenient": false,
+														"zero_terms_query": "NONE",
+														"boost": 1.0
+													}
+												}
+											},
+											{
+												"match": {
+													"collector.default.ja_ngrams": {
+														"query": "berlin",
+														"operator": "OR",
+														"analyzer": "ja_search_ngram",
 														"fuzziness": "1",
 														"prefix_length": 2,
 														"max_expansions": 50,


### PR DESCRIPTION
- added ja_ngrams and ja_raw into collector.default's fields in order to index by two languages.
- added some if statement in PhotonQueryBuilder to use `collector.default.ja_ngrams` when `lang=ja`