### PR TITLE
search on osm key value as a collector field using synonym anlyzer

### DIFF
--- a/es/index_settings.json
+++ b/es/index_settings.json
@@ -61,6 +61,13 @@
 					"lowercase",
 					"preserving_word_delimiter"],
 				"tokenizer": "standard" 
+			},
+			"synonym_analyzer": {
+				"tokenizer": "standard",
+				"filter": [
+					"lowercase",
+					"synonym_filter"
+				]
 			}
 		},
 		"tokenizer": {
@@ -94,6 +101,15 @@
 			"preserving_word_delimiter": { 
 				"type": "word_delimiter",
 				"preserve_original": "true"
+			},
+			"synonym_filter": {
+				"type": "synonym",
+				"synonyms": [
+					"international airport, airport, aeroway, aerodrome",
+					"zipline, zip Line, aerialway, zip_line",
+					"car station, station, stop"
+				],
+				"tokenizer": "whitespace"
 			}
 		}
 	}

--- a/es/mappings.json
+++ b/es/mappings.json
@@ -132,6 +132,10 @@
 						"copy_to": [
 							"collector.it"
 						]
+					},
+					"osm_key_value": {
+						"type": "text",
+						"analyzer": "synonym_analyzer"
 					}
 				}
 			},
@@ -402,7 +406,10 @@
 			},
 			"osm_key": {
 				"type": "keyword",
-				"index": true
+				"index": true,
+				"copy_to": [
+					"collector.osm_key_value"
+				]
 			},
 			"osm_type": {
 				"type": "text",
@@ -410,7 +417,10 @@
 			},
 			"osm_value": {
 				"type": "keyword",
-				"index": true
+				"index": true,
+				"copy_to": [
+					"collector.osm_key_value"
+				]
 			},
 			"object_type": {
 				"type": "text",
@@ -540,7 +550,7 @@
 					}
 				}
 			},
-	  		"locality": {
+			"locality": {
 				"properties": {
 					"de": {
 						"type": "text",

--- a/src/main/java/de/komoot/photon/query/PhotonQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/query/PhotonQueryBuilder.java
@@ -86,7 +86,9 @@ public class PhotonQueryBuilder {
                 .should(QueryBuilders.matchQuery(String.format("name.%s.raw", language), query).boost(200)
                         .analyzer("search_raw"))
                 .should(QueryBuilders.matchQuery(String.format("collector.%s.raw", language), query).boost(100)
-                        .analyzer("search_raw"));
+                        .analyzer("search_raw"))
+                .should(QueryBuilders.matchQuery("collector.osm_key_value", query).boost(300)
+                        .analyzer("synonym_analyzer"));
 
         // this is former general-score, now inline
         String strCode = "double score = 1 + doc['importance'].value * 100; score";

--- a/src/test/resources/json_queries/test_base_query.json
+++ b/src/test/resources/json_queries/test_base_query.json
@@ -81,6 +81,21 @@
 											"boost": 100.0
 										}
 									}
+								},
+								{
+									"match": {
+										"collector.osm_key_value": {
+											"query": "berlin",
+											"operator": "OR",
+											"analyzer": "synonym_analyzer",
+											"prefix_length": 0,
+											"max_expansions": 50,
+											"fuzzy_transpositions": true,
+											"lenient": false,
+											"zero_terms_query": "NONE",
+											"boost": 300.0
+										}
+									}
 								}
 							],
 							"disable_coord": false,

--- a/src/test/resources/json_queries/test_base_query_fr.json
+++ b/src/test/resources/json_queries/test_base_query_fr.json
@@ -81,6 +81,21 @@
 											"boost": 100.0
 										}
 									}
+								},
+								{
+									"match": {
+										"collector.osm_key_value": {
+											"query": "berlin",
+											"operator": "OR",
+											"analyzer": "synonym_analyzer",
+											"prefix_length": 0,
+											"max_expansions": 50,
+											"fuzzy_transpositions": true,
+											"lenient": false,
+											"zero_terms_query": "NONE",
+											"boost": 300.0
+										}
+									}
 								}
 							],
 							"disable_coord": false,


### PR DESCRIPTION
This PR uses the `collector.osm_key_value` field that is created by copying the `osm_key` and `osm_value` to a text field then analyzing that new field using a new `synonym_analyzer`.

When searching we boost the response where the `collector.osm_key_value LIKE query`