### PR TITLE
mingram=2にしたja_edge_gramを適用したja_index_ngramを追加

### DIFF
--- a/es/index_settings.json
+++ b/es/index_settings.json
@@ -1,6 +1,23 @@
 {
 	"analysis": {
 		"analyzer": {
+			"ja_index_ngram": {
+				"char_filter": [
+					"punctuationgreedy",
+					"remove_ws_hnr_suffix",
+					"ja_normalize",
+					"kuromoji_iteration_mark"
+				],
+				"tokenizer": "ja_edge_ngram",
+				"filter": [
+					"preserving_word_delimiter",
+					"lowercase",
+					"german_normalization",
+					"asciifolding",
+					"unique",
+					"ja_romaji_readingform"
+				]
+			},
 			"ja_index_raw": {
 				"type": "custom",
 				"char_filter": [
@@ -128,6 +145,15 @@
 			"edge_ngram": {
 				"type": "edge_ngram",
 				"min_gram": 1,
+				"max_gram": 100,
+				"token_chars": [
+					"letter",
+					"digit"
+				]
+			},
+			"ja_edge_ngram": {
+				"type": "edge_ngram",
+				"min_gram": 2,
 				"max_gram": 100,
 				"token_chars": [
 					"letter",

--- a/es/mappings.json
+++ b/es/mappings.json
@@ -25,8 +25,15 @@
 				"properties": {
 					"default": {
 						"type": "text",
-						"analyzer": "index_ngram",
 						"fields": {
+							"ngrams": {
+								"type": "text",
+								"analyzer": "index_ngram"
+							},
+							"ngrams_ja": {
+								"type": "text",
+								"analyzer": "ja_index_ngram"
+							},
 							"raw": {
 								"type": "text",
 								"analyzer": "index_raw"
@@ -44,7 +51,7 @@
 						"fields": {
 							"ngrams": {
 								"type": "text",
-								"analyzer": "index_ngram"
+								"analyzer": "ja_index_ngram"
 							},
 							"raw": {
 								"type": "text",
@@ -132,7 +139,7 @@
 						"fields": {
 							"ngrams": {
 								"type": "text",
-								"analyzer": "index_ngram"
+								"analyzer": "ja_index_ngram"
 							},
 							"raw": {
 								"type": "text",

--- a/src/main/java/de/komoot/photon/query/PhotonQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/query/PhotonQueryBuilder.java
@@ -63,7 +63,7 @@ public class PhotonQueryBuilder {
         QueryBuilder collectorQuery;
         if (lenient) {
             BoolQueryBuilder builder = QueryBuilders.boolQuery()
-                    .should(QueryBuilders.matchQuery("collector.default", query)
+                    .should(QueryBuilders.matchQuery(Arrays.asList(cjkLanguages).contains(language) ? String.format("collector.default.ngrams_%s", language): "collector.default.ngrams", query)
                             .fuzziness(Fuzziness.ONE)
                             .prefixLength(2)
                             .analyzer("search_ngram")
@@ -96,7 +96,7 @@ public class PhotonQueryBuilder {
             collectorQuery = builder;
         } else {
             MultiMatchQueryBuilder builderDefault =
-                    QueryBuilders.multiMatchQuery(query).field("collector.default", 1.0f).type(MultiMatchQueryBuilder.Type.CROSS_FIELDS).prefixLength(2).analyzer("search_ngram").minimumShouldMatch("100%");
+                    QueryBuilders.multiMatchQuery(query).field(Arrays.asList(cjkLanguages).contains(language) ? String.format("collector.default.ngrams_%s", language): "collector.default.ngrams", 1.0f).type(MultiMatchQueryBuilder.Type.CROSS_FIELDS).prefixLength(2).analyzer("search_ngram").minimumShouldMatch("100%");
 
             for (String lang : languages) {
                 builderDefault.field(String.format("collector.%s.ngrams", lang), lang.equals(language) ? 1.0f : 0.6f);

--- a/src/test/resources/json_queries/test_base_query.json
+++ b/src/test/resources/json_queries/test_base_query.json
@@ -11,7 +11,7 @@
 										"should": [
 											{
 												"match": {
-													"collector.default": {
+													"collector.default.ngrams": {
 														"query": "berlin",
 														"operator": "OR",
 														"analyzer": "search_ngram",

--- a/src/test/resources/json_queries/test_base_query_fr.json
+++ b/src/test/resources/json_queries/test_base_query_fr.json
@@ -11,7 +11,7 @@
 										"should": [
 											{
 												"match": {
-													"collector.default": {
+													"collector.default.ngrams": {
 														"query": "berlin",
 														"operator": "OR",
 														"analyzer": "search_ngram",

--- a/src/test/resources/json_queries/test_base_query_ja.json
+++ b/src/test/resources/json_queries/test_base_query_ja.json
@@ -11,7 +11,7 @@
 										"should": [
 											{
 												"match": {
-													"collector.default": {
+													"collector.default.ngrams_ja": {
 														"query": "berlin",
 														"operator": "OR",
 														"analyzer": "search_ngram",


### PR DESCRIPTION
日本語の最小単位は2文字以上なので、mingram=2にした`ja_index_ngram`を作ってみた。search_ngramは日本語専用のは作ってない。またcollector.defaultにngram,ngram_jaの2つを追加