### PR TITLE
add matchPhraseQuery at No.4 query for Japanese searching

### DIFF
--- a/src/main/java/de/komoot/photon/query/PhotonQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/query/PhotonQueryBuilder.java
@@ -62,13 +62,13 @@ public class PhotonQueryBuilder {
             collectorQuery = QueryBuilders.boolQuery()
                     .should(QueryBuilders.matchQuery(Arrays.asList(cjkLanguages).contains(language) ? String.format("collector.default.raw_%s", language) : "collector.default", query)
                             .fuzziness(Fuzziness.ONE)
-                            .prefixLength(2)
+                            .prefixLength(Arrays.asList(cjkLanguages).contains(language) ? 0 : 2)
                             .operator(Arrays.asList(cjkLanguages).contains(language) ? Operator.AND : Operator.OR)
                             .analyzer(Arrays.asList(cjkLanguages).contains(language) ? String.format("%s_search_raw", language) : "search_ngram")
                             .minimumShouldMatch("-1"))
                     .should(QueryBuilders.matchQuery(Arrays.asList(cjkLanguages).contains(language) ? String.format("collector.%s.raw", language) : String.format("collector.%s.ngrams", language), query)
                             .fuzziness(Fuzziness.ONE)
-                            .prefixLength(2)
+                            .prefixLength(Arrays.asList(cjkLanguages).contains(language) ? 0 : 2)
                             .operator(Arrays.asList(cjkLanguages).contains(language) ? Operator.AND : Operator.OR)
                             .analyzer(Arrays.asList(cjkLanguages).contains(language) ? String.format("%s_search_raw", language) : "search_ngram")
                             .minimumShouldMatch("-1"))
@@ -78,7 +78,7 @@ public class PhotonQueryBuilder {
                     QueryBuilders.multiMatchQuery(query)
                             .field(Arrays.asList(cjkLanguages).contains(language) ? String.format("collector.default.raw_%s", language) : "collector.default", 1.0f)
                             .type(Arrays.asList(cjkLanguages).contains(language) ? MultiMatchQueryBuilder.Type.BEST_FIELDS : MultiMatchQueryBuilder.Type.CROSS_FIELDS)
-                            .prefixLength(2)
+                            .prefixLength(Arrays.asList(cjkLanguages).contains(language) ? 0 : 2)
                             .operator(Arrays.asList(cjkLanguages).contains(language) ? Operator.AND : Operator.OR)
                             .minimumShouldMatch("100%");
             if (!Arrays.asList(cjkLanguages).contains(language)) {
@@ -134,6 +134,7 @@ public class PhotonQueryBuilder {
         // 4. Rerank results for having the full name in the default language.
         if (Arrays.asList(cjkLanguages).contains(language)) {
             query4QueryBuilder
+                    .should(QueryBuilders.matchQuery(String.format("name.%s.raw", language), query).operator(Operator.AND))
                     .should(QueryBuilders.boolQuery()
                             .should(QueryBuilders.matchQuery(String.format("name.%s.raw", language), query))
                             .should(QueryBuilders.matchPhrasePrefixQuery(String.format("name.%s.raw", language), query)));


### PR DESCRIPTION
changed prefix_length to zero for ja

<details>

```js
{
  url: 'http://35.221.70.13:2322/api?q=narita%20airport&lang=ja',
  q: 'narita airport',
  result: '["成田国際空港(house,aerodrome,aeroway,成田市,千葉県,日本,282-0004)","Narita Airport Hostel(house,hostel,tourism,芝山町,千葉県,日本,289-1606)","成田空港(house,station,railway,成田市,千葉県,日本,282-0004)","空港第2ビル(house,station,railway,成田市,千葉県,日本,282-0004)","警察署(house,police,amenity,成田市,千葉県,日本,282-0004)","ヒルトン成田(house,hotel,tourism,成田市,千葉県,日本,286 0127)","成田空港空と大地の歴史館(house,museum,tourism,芝山町,千葉県,日本,289-1608)","成田東武ホテルエアポート(house,hotel,tourism,成田市,千葉県,日本,282-0004)","成田空港(house,stop,railway,成田市,千葉県,日本,282-0004)","成田空港(house,station,railway,成田市,千葉県,日本,282-0004)","成田空港(house,stop,railway,成田市,千葉県,日本,282-0004)","成田空港(house,stop,railway,成田市,千葉県,日本,282-0004)","成田空港(house,stop,railway,成田市,千葉県,日本,282-0004)","成田空港(house,stop,railway,成田市,千葉県,日本,282-0004)","空港第2ビル(house,stop,railway,成田市,千葉県,日本,282-0004)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=narita%20airport&lang=en',
  q: 'narita airport',
  result: '["Narita International Airport(house,aerodrome,aeroway,Narita,Chiba Prefecture,Japan,282-0004)","Narita Airport Terminal 1(house,station,railway,Narita,Chiba Prefecture,Japan,282-0004)","Narita Airport Terminal 2·3(house,station,railway,Narita,Chiba Prefecture,Japan,282-0004)","Narita International Airport Police Station(house,police,amenity,Narita,Chiba Prefecture,Japan,282-0004)","Hilton Tokyo Narita Airport(house,hotel,tourism,Narita,Chiba Prefecture,Japan,286 0127)","Narita Airport and Community Historical Museum(house,museum,tourism,Shibayama,Chiba Prefecture,Japan,289-1608)","Narita Airport Hostel(house,hostel,tourism,Shibayama,Chiba Prefecture,Japan,289-1606)","Narita Tobu Hotel Airport(house,hotel,tourism,Narita,Chiba Prefecture,Japan,282-0004)","Narita Airport Terminal 1(house,station,railway,Narita,Chiba Prefecture,Japan,282-0004)","Narita Airport Terminal 1(house,stop,railway,Narita,Chiba Prefecture,Japan,282-0004)","Narita Airport Terminal 1(house,stop,railway,Narita,Chiba Prefecture,Japan,282-0004)","Narita Airport Terminal 1(house,stop,railway,Narita,Chiba Prefecture,Japan,282-0004)","Narita Airport Resthouse(house,hotel,tourism,Narita,Chiba Prefecture,Japan,282-0004)","Narita Airport Terminal 1(house,stop,railway,Narita,Chiba Prefecture,Japan,282-0004)","Narita Airport Terminal 1(house,stop,railway,Narita,Chiba Prefecture,Japan,282-0004)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E6%88%90%E7%94%B0%E5%9B%BD%E9%9A%9B%E7%A9%BA%E6%B8%AF&lang=ja',
  q: '成田国際空港',
  result: '["成田国際空港(house,aerodrome,aeroway,成田市,千葉県,日本,282-0004)","成田空港(house,station,railway,成田市,千葉県,日本,282-0004)","警察署(house,police,amenity,成田市,千葉県,日本,282-0004)","成田国際空港第2ターミナル(house,terminal,aeroway,成田市,千葉県,日本,282-0004)","成田国際空港株式会社(house,company,office,成田市,千葉県,日本,282-0004)","成田空港(house,stop,railway,成田市,千葉県,日本,282-0004)","成田国際空港郵便局(house,post_office,amenity,成田市,千葉県,日本,282-0004)","成田空港(house,stop,railway,成田市,千葉県,日本,282-0004)","成田空港(house,stop,railway,成田市,千葉県,日本,282-0004)","成田空港(house,station,railway,成田市,千葉県,日本,282-0004)","成田空港(house,stop,railway,成田市,千葉県,日本,282-0004)","トヨタレンタカー 成田空港店(house,car_rental,amenity,成田市,千葉県,日本,282-0004)","ニッポンレンタカー 成田空港(house,car_rental,amenity,成田市,千葉県,日本,282-0004)","成田空港駐車場タニカワパーキング(house,parking,amenity,成田市,千葉県,日本,286 0127)","成田空港(house,stop,railway,成田市,千葉県,日本,282-0004)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E6%88%90%E7%94%B0%E7%A9%BA%E6%B8%AF&lang=ja',
  q: '成田空港',
  result: '["成田空港(house,station,railway,成田市,千葉県,日本,282-0004)","成田国際空港(house,aerodrome,aeroway,成田市,千葉県,日本,282-0004)","成田空港(house,stop,railway,成田市,千葉県,日本,282-0004)","トヨタレンタカー 成田空港店(house,car_rental,amenity,成田市,千葉県,日本,282-0004)","ニッポンレンタカー 成田空港(house,car_rental,amenity,成田市,千葉県,日本,282-0004)","成田空港(house,station,railway,成田市,千葉県,日本,282-0004)","成田空港(house,stop,railway,成田市,千葉県,日本,282-0004)","成田空港空と大地の歴史館(house,museum,tourism,芝山町,千葉県,日本,289-1608)","成田空港駐車場タニカワパーキング(house,parking,amenity,成田市,千葉県,日本,286 0127)","成田空港(house,stop,railway,成田市,千葉県,日本,282-0004)","成田空港(house,stop,railway,成田市,千葉県,日本,282-0004)","Honda Cars 東総 成田空港通り店(house,car,shop,成田市,千葉県,日本,286-0021)","成田空港(house,stop,railway,成田市,千葉県,日本,282-0004)","成田空港温泉 空の湯(house,public_bath,amenity,芝山町,千葉県,日本,289-2232)","成田空港第一ターミナル(house,terminal,aeroway,成田市,千葉県,日本,282-0004)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=shizuoka&lang=ja',
  q: 'shizuoka',
  result: '["静岡市(city,city,place,静岡県,日本,420-8602)","Shizuoka BMW(house,car,shop,静岡市,駿河区,静岡県,日本,422-8550)","静岡県(state,province,place,日本)","静岡ＳＡ（下り）大型Ｐ(house,parking,amenity,静岡市,葵区,静岡県,日本,420-8602)","静岡(house,stop,railway,静岡市,葵区,静岡県,日本,420-8602)","静岡(house,station,railway,静岡市,駿河区,静岡県,日本,422-8550)","静岡(house,stop,railway,静岡市,駿河区,静岡県,日本,422-8550)","静岡(house,stop,railway,静岡市,葵区,静岡県,日本,420-8602)","静岡(house,stop,railway,静岡市,葵区,静岡県,日本,420-8602)","静岡(house,station,railway,静岡市,葵区,静岡県,日本,420-8602)","Shizuoka University Library(house,library,amenity,静岡市,駿河区,静岡県,日本,422-8550)","静岡(house,stop,railway,静岡市,駿河区,静岡県,日本,422-8550)","静岡(house,stop,railway,静岡市,葵区,静岡県,日本,420-8602)","静岡ＳＡ（上り）小型Ｐ(house,parking,amenity,静岡市,葵区,静岡県,日本,420-8602)","静岡ＳＡ（下り）小型Ｐ(house,parking,amenity,静岡市,葵区,静岡県,日本,420-8602)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=shizuoka&lang=en',
  q: 'shizuoka',
  result: '["Shizuoka(city,city,place,Shizuoka Prefecture,Japan,420-8602)","Shizuoka Prefecture(state,province,place,Japan)","Shizuoka(house,stop,railway,Shizuoka,Aoi Ward,Shizuoka Prefecture,Japan,420-8602)","Shizuoka(house,stop,railway,Shizuoka,Aoi Ward,Shizuoka Prefecture,Japan,420-8602)","Shizuoka(house,stop,railway,Shizuoka,Aoi Ward,Shizuoka Prefecture,Japan,420-8602)","Shizuoka(house,station,railway,Shizuoka,Aoi Ward,Shizuoka Prefecture,Japan,420-8602)","Shizuoka(house,station,railway,Shizuoka,Suruga Ward,Shizuoka Prefecture,Japan,422-8550)","Shizuoka(house,stop,railway,Shizuoka,Suruga Ward,Shizuoka Prefecture,Japan,422-8550)","Shizuoka(house,stop,railway,Shizuoka,Aoi Ward,Shizuoka Prefecture,Japan,420-8602)","Shizuoka(house,stop,railway,Shizuoka,Suruga Ward,Shizuoka Prefecture,Japan,422-8550)","Shizuoka Stadium ECOPA(house,stadium,leisure,Fukuroi,Shizuoka Prefecture,Japan,436-0048)","Shin-shizuoka(house,stop,railway,Shizuoka,Aoi Ward,Shizuoka Prefecture,Japan,420-8602)","Shin-shizuoka(house,station,railway,Shizuoka,Aoi Ward,Shizuoka Prefecture,Japan,420-8602)","Shin-shizuoka(house,stop,railway,Shizuoka,Aoi Ward,Shizuoka Prefecture,Japan,420-8602)","Higashi-Shizuoka(house,stop,railway,Shizuoka,Aoi Ward,Shizuoka Prefecture,Japan,420-8602)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E9%9D%99%E5%B2%A1&lang=ja',
  q: '静岡',
  result: '["静岡県(state,province,place,日本)","静岡市(city,city,place,静岡県,日本,420-8602)","静岡(house,stop,railway,静岡市,葵区,静岡県,日本,420-8602)","静岡(house,station,railway,静岡市,葵区,静岡県,日本,420-8602)","静岡(house,station,railway,静岡市,駿河区,静岡県,日本,422-8550)","静岡(house,stop,railway,静岡市,駿河区,静岡県,日本,422-8550)","静岡(house,stop,railway,静岡市,葵区,静岡県,日本,420-8602)","静岡(house,stop,railway,静岡市,葵区,静岡県,日本,420-8602)","静岡(house,stop,railway,静岡市,葵区,静岡県,日本,420-8602)","静岡(house,stop,railway,静岡市,駿河区,静岡県,日本,422-8550)","静岡英和学院大学(house,school,amenity,静岡市,駿河区,静岡県,日本,422-8550)","静岡文化芸術大学(house,university,amenity,浜松市,中区,静岡県,日本,430-0918)","静岡競輪場(house,stadium,leisure,静岡市,駿河区,静岡県,日本,422-8550)","静岡刑務所(house,prison,amenity,静岡市,葵区,静岡県,日本,420-8602)","静岡県立大学短期大学部(house,college,amenity,静岡市,駿河区,静岡県,日本,422-8550)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E9%9D%99%E5%B2%A1%E7%9C%8C&lang=ja',
  q: '静岡県',
  result: '["静岡県(state,province,place,日本)","静岡県立大学短期大学部(house,college,amenity,静岡市,駿河区,静岡県,日本,422-8550)","静岡県庁 本館(house,yes,building,静岡市,葵区,静岡県,日本,420-8602)","静岡県立浜松商業高等学校(house,school,amenity,浜松市,中区,静岡県,日本,432-8012)","静岡県立沼津東高等学校(house,school,amenity,沼津市,静岡県,日本,410-0013)","静岡県立総合病院(house,hospital,amenity,静岡市,葵区,静岡県,日本,420-8602)","静岡県立美術館(house,museum,tourism,静岡市,清水区,静岡県,日本,424-8701)","静岡県立浜松西高等学校中等部(house,school,amenity,浜松市,中区,静岡県,日本,432-8038)","静岡県立こども病院(house,hospital,amenity,静岡市,葵区,静岡県,日本,420-8602)","静岡県柑橘試験場落葉果樹分場(locality,commercial,landuse,浜松市,北区,静岡県,日本)","静岡県立掛川東高等学校(house,school,amenity,掛川市,静岡県,日本,436-0056)","静岡県立川根高等学校(house,school,amenity,川根本町,静岡県,日本,428-0312)","静岡県立中央図書館(house,library,amenity,静岡市,清水区,静岡県,日本,424-8701)","静岡県立浜名高等学校(house,school,amenity,浜松市,浜北区,静岡県,日本,434-8502)","静岡県立遠江総合高等学校(house,school,amenity,森町,静岡県,日本,4370215)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E6%9D%BE%E6%9C%AC&lang=ja',
  q: '松本',
  result: '["松本市(city,city,place,長野県,日本)","松本城(house,castle,historic,松本市,葭町,長野県,日本,390-0874)","松本城(house,museum,tourism,松本市,葭町,長野県,日本,390-0874)","松本大学(house,university,amenity,松本市,新村,長野県,日本,390-1701)","松本空港ターミナルビル(house,terminal,aeroway,松本市,空港東,長野県,日本,3990033)","松本(house,station,railway,松本市,長野県,日本,3900874)","松本(house,station,railway,松本市,長野県,日本,3900874)","松本歯科大学(house,college,amenity,塩尻市,郷原,長野県,日本,399-6461)","松本市美術館(house,museum,tourism,松本市,長野県,日本,390−0815)","松本神社(locality,religious,landuse,日本)","松本(district,administrative,boundary,青森市,青森県,日本)","松本産業(locality,industrial,landuse,尼崎市,兵庫県,日本)","松本神社(locality,religious,landuse,日本,780-8571)","日比谷 松本楼(house,restaurant,amenity,東京都,千代田区,日本,100-0012)","松本(locality,quarter,place,福井市,福井県,日本,910-0003)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E5%93%81%E5%B7%9D%E9%A7%85&lang=ja',
  q: '品川駅',
  result: '["品川駅(house,train_station,building,東京都,品川,日本,108-0075)","品川駅港南商店街(locality,retail,landuse,東京都,品川,日本,108-0075)","品川駅東口(house,bus_stop,highway,東京都,品川,日本,108-0075)","品川駅港南口(house,bus_stop,highway,東京都,品川,日本,108-0075)","品川駅港南口交番(house,police,amenity,東京都,品川,日本,108-0075)","品川駅高輪口(house,bus_stop,highway,東京都,品川,日本,108-8611)","品川駅西口(高輪口)(house,bus_stop,highway,東京都,品川,日本,108-8611)","品川駅高輪口(house,bus_station,amenity,東京都,品川,日本,108-8611)","ユアーズ・パーキング 品川駅タワー(house,parking,amenity,東京都,品川,日本,108-8611)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E6%9D%B1%E4%BA%AC%E9%A7%85&lang=ja',
  q: '東京駅',
  result: '["東京駅(house,bus_stop,highway,東京都,中央区,日本,100-6633)","東京駅(house,bus_stop,highway,東京都,中央区,日本,103-8238)","東京駅南口(house,traffic_signals,highway,東京都,千代田区,日本,100-0005)","東京駅中央口(house,traffic_signals,highway,東京都,神田,日本,100-0005)","東京駅一番街(house,retail,building,東京都,神田,日本,100-0005)","東京駅(house,bus_stop,highway,東京都,中央区,日本,103-0028)","東京駅 (京葉線)(house,subway_entrance,railway,東京都,千代田区,日本,100-0005)","東京駅八重洲口(house,bus_stop,highway,東京都,中央区,日本,100-6633)","東京駅 (京葉線)(house,subway_entrance,railway,東京都,千代田区,日本,100-0005)","東京駅丸の内北口(house,bus_stop,highway,東京都,千代田区,日本,100-0005)","東京駅南口(house,bus_stop,highway,東京都,千代田区,日本,100-0005)","東京駅八重洲口(house,bus_stop,highway,東京都,千代田区,日本,100-0005)","東京駅八重洲南口(house,bus_station,amenity,東京都,中央区,日本,100-6633)","東京駅丸の内南口(house,bus_stop,highway,東京都,千代田区,日本,100-0005)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E7%94%A3%E6%A5%AD%E6%8C%AF%E8%88%88%E3%82%BB%E3%83%B3%E3%82%BF%E3%83%BC%20%E5%A4%A7%E9%98%AA&lang=ja',
  q: '産業振興センター 大阪',
  result: '["堺市産業振興センター（じばしん南大阪）第2駐車場(house,parking,amenity,堺市,北区,大阪府,日本,540-8570)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E7%94%A3%E6%A5%AD%E6%8C%AF%E8%88%88%E3%82%BB%E3%83%B3%E3%82%BF%E3%83%BC&lang=ja',
  q: '産業振興センター',
  result: '["産業振興センター(house,stop,railway,横浜市,金沢区,神奈川県,日本,231-0017)","産業振興センター(house,station,railway,横浜市,金沢区,神奈川県,日本,231-0017)","産業振興センター(house,stop,railway,横浜市,金沢区,神奈川県,日本,231-0017)","産業振興センター(house,community_centre,amenity,東京都,杉並区,日本,167-0051)","産業振興センター(house,company,office,札幌市,白石区,北海道,日本,003-0806)","産業振興センター前(house,traffic_signals,highway,横浜市,金沢区,神奈川県,日本,231-0017)","産業振興センター診療所(house,doctors,amenity,横浜市,金沢区,神奈川県,日本,231-0017)","産業振興センター(house,bus_stop,highway,横浜市,金沢区,神奈川県,日本,231-0017)","産業振興センター前(house,bus_stop,highway,新潟市,中央区,新潟県,日本,950-0941)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E4%BC%8A%E6%9D%B1%E5%B8%82%E9%8E%8C%E7%94%B0&lang=ja',
  q: '伊東市鎌田',
  result: '["鎌田幼稚園(house,kindergarten,amenity,伊東市,静岡県,日本,414-0022)","伊東鎌田郵便局(house,post_office,amenity,伊東市,静岡県,日本,414-0022)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E6%9D%B1%E4%BA%AC%E3%82%BF%E3%83%AF%E3%83%BC&lang=ja',
  q: '東京タワー',
  result: '["東京タワー(house,tower,man_made,東京都,麻布,日本,105-0011)","東京タワー(house,attraction,tourism,東京都,麻布,日本,105-0011)","東京タワー通り(street,tertiary,highway,東京都,麻布,日本,106-0041)","東京タワー通り(street,tertiary,highway,東京都,麻布,日本,105-0011)","東京タワー(house,bus_stop,highway,東京都,麻布,日本,105-0011)","東京タワー前(house,traffic_signals,highway,東京都,麻布,日本,105-0011)","愛宕警察署 東京タワー前交番(house,police,amenity,東京都,麻布,日本,105-0011)","東京日本橋タワー(house,commercial,building,東京都,中央区,日本,103-6090)","タワーレコード渋谷店(house,music,shop,東京都,渋谷区,日本,150-0041)","東京スカイツリー イーストタワー(house,commercial,building,東京都,墨田区,日本,131-0045)","東京日本橋タワーアネックス(locality,construction,landuse,日本)","御成門(house,stop,railway,東京都,港区,日本,105-8799)","御成門(house,station,railway,東京都,港区,日本,105-8799)","御成門(house,stop,railway,東京都,港区,日本,105-8799)","東京オペラシティ(house,yes,building,東京都,新宿区,日本,163-1490)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E9%8E%8C%E5%80%89%E5%AD%A6%E5%9C%92&lang=ja',
  q: '鎌倉学園',
  result: '["鎌倉学園中・高等学校(house,school,amenity,鎌倉市,台,神奈川県,日本,247-0062)","鎌倉市立玉縄小学校(house,school,amenity,鎌倉市,一丁目,神奈川県,日本,247-0072)","前橋市立 鎌倉中学校(house,school,amenity,前橋市,群馬県,日本,371-0018)","鎌倉薫風学園(house,social_facility,amenity,鎌倉市,関谷,神奈川県,日本,245-0065)","鎌倉自動車学校(house,school,amenity,鎌倉市,一丁目,神奈川県,日本,246)","鎌倉自動車学校(house,driving_school,amenity,鎌倉市,一丁目,神奈川県,日本,246)","鎌倉小学校(house,bus_stop,highway,東京都,葛飾区,日本,〒133-0056)","鎌倉市立小坂小学校(house,school,amenity,鎌倉市,小袋谷,神奈川県,日本,247-0061)","鎌倉市立 大船中学校(house,school,amenity,鎌倉市,小袋谷,神奈川県,日本,247-0061)","鎌倉市立植木小学校(house,yes,building,鎌倉市,四丁目,神奈川県,日本,247-0071)","鎌倉市立植木小学校(house,school,amenity,鎌倉市,四丁目,神奈川県,日本,247-0071)","鎌倉市立関谷小学校(house,school,amenity,鎌倉市,関谷,神奈川県,日本,244-0844)","葛飾区立 鎌倉小学校(house,school,amenity,東京都,葛飾区,日本,〒125-0053)","鎌倉養護学校(肢体不自由)(知的障害)(house,school,amenity,鎌倉市,関谷,神奈川県,日本,244-0844)","鎌倉パスタ(house,restaurant,amenity,東京都,練馬区,日本,178-0063)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E4%BC%8A%E6%9D%B1%20%E3%82%B3%E3%83%B3%E3%83%93%E3%83%8B&lang=ja',
  q: '伊東 コンビニ',
  result: '["セブンイレブン 伊東湯川店(house,convenience,shop,伊東市,静岡県,日本,414-0002)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E4%BC%8A%E6%9D%B1%20%E6%B8%A9%E6%B3%89&lang=ja',
  q: '伊東 温泉',
  result: '["立ち寄り温泉;伊東高原の湯(house,parking,amenity,伊東市,静岡県,日本,413-0232)","立ち寄り温泉;伊東高原の湯(house,public_bath,amenity,伊東市,静岡県,日本,413-0232)","温泉民宿 鈴幸(house,guest_house,tourism,伊東市,静岡県,日本,414-0002)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=414-0054&lang=ja',
  q: '414-0054',
  result: '[]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E9%9D%99%E5%B2%A1%E7%9C%8C%E7%86%B1%E6%B5%B7%E5%B8%82%E7%94%B0%E5%8E%9F%E6%9C%AC%E7%94%BA&lang=ja',
  q: '静岡県熱海市田原本町',
  result: '["熱海(house,stop,railway,熱海市,静岡県,日本,413-0005)","熱海(house,stop,railway,熱海市,静岡県,日本,413-0005)","熱海(house,stop,railway,熱海市,静岡県,日本,413-0005)","熱海(house,stop,railway,熱海市,静岡県,日本,413-0005)","熱海(house,stop,railway,熱海市,静岡県,日本,413-0005)","熱海(house,train_station,building,熱海市,静岡県,日本,413-0005)","熱海(house,stop,railway,熱海市,静岡県,日本,413-0005)","熱海(house,station,railway,熱海市,静岡県,日本,413-0005)","熱海(house,stop,railway,熱海市,静岡県,日本,413-0005)","熱海(house,station,railway,熱海市,静岡県,日本,413-0005)","田原本町(locality,quarter,place,熱海市,静岡県,日本,413-0011)","熱海停車場線(street,secondary,highway,熱海市,静岡県,日本,413-0005)","市立桃山小学校(house,school,amenity,熱海市,静岡県,日本,413-0011)","熱海(house,platform,railway,熱海市,静岡県,日本,413-0011)","熱海(house,platform,railway,熱海市,静岡県,日本,413-0011)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E7%A5%9E%E5%A5%88%E5%B7%9D%E7%9C%8C%E8%8C%85%E3%83%B6%E5%B4%8E%E5%B8%82&lang=ja',
  q: '神奈川県茅ヶ崎市',
  result: '["茅ヶ崎市(city,city,place,神奈川県,日本)","茅ヶ崎(house,stop,railway,茅ヶ崎市,神奈川県,日本,253-0053)","茅ヶ崎(house,stop,railway,茅ヶ崎市,神奈川県,日本,253-0053)","茅ヶ崎(house,stop,railway,茅ヶ崎市,神奈川県,日本,253-0053)","茅ヶ崎(house,station,railway,茅ヶ崎市,神奈川県,日本,253-0053)","茅ヶ崎(house,stop,railway,茅ヶ崎市,神奈川県,日本,253-0053)","茅ヶ崎(house,stop,railway,茅ヶ崎市,神奈川県,日本,253-0053)","茅ヶ崎(house,stop,railway,茅ヶ崎市,神奈川県,日本,253-0053)","茅ヶ崎(house,station,railway,茅ヶ崎市,神奈川県,日本,253-0053)","茅ヶ崎JCT(house,motorway_junction,highway,茅ヶ崎市,神奈川県,日本,253-0083)","茅ヶ崎市立病院(house,hospital,amenity,茅ヶ崎市,神奈川県,日本,253-8686)","茅ヶ崎機械産業(locality,industrial,landuse,茅ヶ崎市,神奈川県,日本)","BASFジャパン(株) 茅ヶ崎工場(locality,industrial,landuse,茅ヶ崎市,神奈川県,日本)","茅ヶ崎看護専門学校(house,school,amenity,茅ヶ崎市,神奈川県,日本,253-0086)","セブンイレブン 茅ヶ崎今宿東店(locality,retail,landuse,茅ヶ崎市,神奈川県,日本)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E3%82%BD%E3%83%8B%E3%83%BC%E3%82%B9%E3%83%88%E3%82%A2%20%E5%A4%A7%E9%98%AA&lang=ja',
  q: 'ソニーストア 大阪',
  result: '["ソニーストア(house,electronics,shop,大阪市,北区,大阪府,日本,530-0001)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E5%8C%97%E5%B2%B3&lang=ja',
  q: '北岳',
  result: '["北岳(locality,peak,natural,日本)","北岳(locality,peak,natural,日本)","北岳(locality,peak,natural,日本)","北岳見晴らし台(locality,locality,place,南アルプス市,山梨県,日本)","北岳肩の小屋(house,alpine_hut,tourism,南アルプス市,山梨県,日本)","北岳の茶屋(house,cafe,amenity,八戸市,青森県,日本,031-0032)","北岳公衆トイレ(house,toilets,amenity,南アルプス市,山梨県,日本)","御岳(locality,peak,natural,日本,892-8677)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E5%A6%99%E9%AB%98%E5%B1%B1&lang=ja',
  q: '妙高山',
  result: '["妙高山(locality,peak,natural,日本)","妙高市立 妙高中学校(house,school,amenity,妙高市,新潟県,日本)","妙高市立妙高保育園(house,kindergarten,amenity,妙高市,新潟県,日本)","山小舎ベルグ(house,guest_house,tourism,妙高市,新潟県,日本,9492112)","山の家Cafe(house,cafe,amenity,妙高市,新潟県,日本,949-2106)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E6%97%A5%E6%9C%AC%E5%A4%A7%E5%AD%A6&lang=ja',
  q: '日本大学',
  result: '["日本大学会館(house,university,building,東京都,千代田区,日本,102-8275)","日本大学高等学校; 日本大学中学校(house,school,amenity,横浜市,港北区,神奈川県,日本,231-0017)","日本大学医学部付属板橋病院(house,hospital,amenity,東京都,板橋区,日本,173-0032)","日本大学 陸上競技場(locality,recreation_ground,landuse,日本,156-0045)","私立 日本大学 第一中学校 第一高等学校(house,school,amenity,東京都,墨田区,日本,130-014)","日本大学山形高等学校 総合運動場(locality,recreation_ground,landuse,日本)","日本大学鶴ヶ丘高等学校 総合運動場(locality,recreation_ground,landuse,日本)","日本大学理工学部御茶ノ水校舎(house,university,amenity,東京都,神田,日本,101-0052)","日本大学病院(house,hospital,amenity,東京都,神田,日本,101-0062)","日本大学(house,university,amenity,藤沢市,神奈川県,日本,252-0813)","日本大学(house,university,building,東京都,世田谷区,日本,154-0002)","日本大学短期大学部(house,college,amenity,三島市,静岡県,日本,4110033)","日本大学（商学部）(house,university,amenity,東京都,神田,日本,101-0061)","日本大学（芸術学部）(house,university,amenity,三芳町,埼玉県,日本,〒354-0045)","日本大学（その他）(house,university,amenity,東京都,神田,日本,101-0061)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E7%9C%8C%E7%AB%8B%E8%8C%85%E3%83%B6%E5%B4%8E%E9%AB%98%E7%AD%89%E5%AD%A6%E6%A0%A1&lang=ja',
  q: '県立茅ヶ崎高等学校',
  result: '["県立茅ヶ崎北陵高等学校(house,school,amenity,茅ヶ崎市,神奈川県,日本,253-0113)","県立茅ヶ崎高等学校(house,school,amenity,茅ヶ崎市,神奈川県,日本,253-0028)","県立茅ヶ崎西浜高等学校(house,school,amenity,茅ヶ崎市,神奈川県,日本,235-0061)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E8%8C%85%E3%83%B6%E5%B4%8E%E9%AB%98%E7%AD%89%E5%AD%A6%E6%A0%A1&lang=ja',
  q: '茅ヶ崎高等学校',
  result: '["東海大学付属第三高等学校(house,school,amenity,茅野市,長野県,日本,391-8512)","茅ヶ崎看護専門学校(house,school,amenity,茅ヶ崎市,神奈川県,日本,253-0086)","印西市立 船穂中学校(house,school,amenity,印西市,千葉県,日本,2701352)","印西市立印西中学校(house,school,amenity,印西市,千葉県,日本,270-1327)","茅ヶ崎学園前(house,bus_stop,highway,茅ヶ崎市,神奈川県,日本,251-0047)","横浜市立 茅ヶ崎中学校(house,school,amenity,横浜市,都筑区,神奈川県,日本,231-0017)","横浜市立 茅ヶ崎小学校(house,school,amenity,横浜市,都筑区,神奈川県,日本,231-0017)","第一中学校入口(house,yes,junction,茅ヶ崎市,神奈川県,日本,235-0061)","阿見町立阿見中学校(house,school,amenity,阿見町,茨城県,日本,300-0336)","茅ヶ崎学園(house,social_facility,amenity,茅ヶ崎市,神奈川県,日本,253-0028)","茅ヶ崎中学入口(house,traffic_signals,highway,横浜市,都筑区,神奈川県,日本,231-0017)","横浜市立 茅ヶ崎東小学校(house,school,amenity,横浜市,都筑区,神奈川県,日本,231-0017)","茅ヶ崎学園入口(house,bus_stop,highway,茅ヶ崎市,神奈川県,日本,253-0028)","印西市立原山小学校(house,school,amenity,印西市,千葉県,日本,2701352)","茅ヶ崎看護専門学校(house,college,amenity,茅ヶ崎市,神奈川県,日本,253-0072)"]'
}
```

</details>