### PR TITLE
adjust No.4 query for Japanese searching

### DIFF
--- a/src/main/java/de/komoot/photon/query/PhotonQueryBuilder.java
+++ b/src/main/java/de/komoot/photon/query/PhotonQueryBuilder.java
@@ -137,10 +137,12 @@ public class PhotonQueryBuilder {
         // 4. Rerank results for having the full name in the default language.
         if (Arrays.asList(cjkLanguages).contains(language)) {
             query4QueryBuilder
-                    .should(QueryBuilders.matchPhraseQuery(String.format("name.%s.raw", language), query))
+                    .should(QueryBuilders.prefixQuery(String.format("name.%s.ngrams", language), query).boost(0.6f))
+                    .should(QueryBuilders.matchPhraseQuery(String.format("name.%s.raw", language), query).boost(1f))
                     .should(QueryBuilders.boolQuery()
                             .must(QueryBuilders.matchQuery(String.format("name.%s.raw", language), query).operator(Operator.AND).fuzziness(Fuzziness.ZERO).fuzzyTranspositions(false).fuzzyRewrite("top_terms_boost_3").minimumShouldMatch("100%"))
-                            .should(QueryBuilders.matchPhrasePrefixQuery(String.format("name.%s.ngrams", language), query)));
+                            .should(QueryBuilders.matchPhraseQuery(String.format("name.%s.ngrams", language), query))
+                    .boost(1f));
         } else {
             query4QueryBuilder
                     .should(QueryBuilders.matchQuery(String.format("name.%s.raw", language), query));


### PR DESCRIPTION
- 東京駅や日光東照宮の時の検索を改善できた
- No.4クエリで組み合わせを少し調整


<details>

```js
{
  url: 'http://35.221.70.13:2322/api?q=narita%20airport&lang=ja',
  q: 'narita airport',
  result: '["Narita Airport Hostel(house,hostel,tourism,芝山町,千葉県,日本,289-1606)","成田国際空港(house,aerodrome,aeroway,成田市,千葉県,日本,282-0004)","成田空港(house,station,railway,成田市,千葉県,日本,282-0004)","空港第2ビル(house,station,railway,成田市,千葉県,日本,282-0004)","警察署(house,police,amenity,成田市,千葉県,日本,282-0004)","ヒルトン成田(house,hotel,tourism,成田市,千葉県,日本,286 0127)","成田空港空と大地の歴史館(house,museum,tourism,芝山町,千葉県,日本,289-1608)","成田東武ホテルエアポート(house,hotel,tourism,成田市,千葉県,日本,282-0004)","成田空港(house,stop,railway,成田市,千葉県,日本,282-0004)","成田空港(house,stop,railway,成田市,千葉県,日本,282-0004)","成田空港(house,station,railway,成田市,千葉県,日本,282-0004)","成田空港(house,stop,railway,成田市,千葉県,日本,282-0004)","空港第2ビル(house,stop,railway,成田市,千葉県,日本,282-0004)","成田空港(house,stop,railway,成田市,千葉県,日本,282-0004)","成田空港第一ターミナル(house,terminal,aeroway,成田市,千葉県,日本,282-0004)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=narita%20airport&lang=en',
  q: 'narita airport',
  result: '["Narita International Airport(house,aerodrome,aeroway,Narita,Chiba Prefecture,Japan,282-0004)","Narita Airport Terminal 1(house,station,railway,Narita,Chiba Prefecture,Japan,282-0004)","Narita Airport Terminal 2·3(house,station,railway,Narita,Chiba Prefecture,Japan,282-0004)","Narita International Airport Police Station(house,police,amenity,Narita,Chiba Prefecture,Japan,282-0004)","Hilton Tokyo Narita Airport(house,hotel,tourism,Narita,Chiba Prefecture,Japan,286 0127)","Narita Airport and Community Historical Museum(house,museum,tourism,Shibayama,Chiba Prefecture,Japan,289-1608)","Narita Airport Hostel(house,hostel,tourism,Shibayama,Chiba Prefecture,Japan,289-1606)","Narita Tobu Hotel Airport(house,hotel,tourism,Narita,Chiba Prefecture,Japan,282-0004)","Narita Airport Terminal 1(house,station,railway,Narita,Chiba Prefecture,Japan,282-0004)","Narita Airport Terminal 1(house,stop,railway,Narita,Chiba Prefecture,Japan,282-0004)","Narita Airport Terminal 1(house,stop,railway,Narita,Chiba Prefecture,Japan,282-0004)","Narita Airport Terminal 1(house,stop,railway,Narita,Chiba Prefecture,Japan,282-0004)","Narita Airport Resthouse(house,hotel,tourism,Narita,Chiba Prefecture,Japan,282-0004)","Narita Airport Terminal 1(house,stop,railway,Narita,Chiba Prefecture,Japan,282-0004)","Narita Airport Terminal 1(house,stop,railway,Narita,Chiba Prefecture,Japan,282-0004)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E6%88%90%E7%94%B0%E5%9B%BD%E9%9A%9B%E7%A9%BA%E6%B8%AF&lang=ja',
  q: '成田国際空港',
  result: '["成田国際空港(house,aerodrome,aeroway,成田市,千葉県,日本,282-0004)","警察署(house,police,amenity,成田市,千葉県,日本,282-0004)","成田空港(house,station,railway,成田市,千葉県,日本,282-0004)","成田国際空港株式会社(house,company,office,成田市,千葉県,日本,282-0004)","成田国際空港第2ターミナル(house,terminal,aeroway,成田市,千葉県,日本,282-0004)","成田国際空港郵便局(house,post_office,amenity,成田市,千葉県,日本,282-0004)","成田国際空港郵便局第１旅客ビル内分室(house,post_office,amenity,成田市,千葉県,日本,282-0004)","第２旅客ビル内分室(house,post_office,amenity,成田市,千葉県,日本,282-0004)","成田空港(house,stop,railway,成田市,千葉県,日本,282-0004)","成田空港(house,station,railway,成田市,千葉県,日本,282-0004)","成田空港(house,stop,railway,成田市,千葉県,日本,282-0004)","成田空港(house,stop,railway,成田市,千葉県,日本,282-0004)","成田空港(house,stop,railway,成田市,千葉県,日本,282-0004)","成田空港(house,stop,railway,成田市,千葉県,日本,282-0004)","成田空港検疫所(house,public,building,成田市,千葉県,日本,282-0004)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E6%88%90%E7%94%B0%E7%A9%BA%E6%B8%AF&lang=ja',
  q: '成田空港',
  result: '["成田空港(house,station,railway,成田市,千葉県,日本,282-0004)","成田国際空港(house,aerodrome,aeroway,成田市,千葉県,日本,282-0004)","成田空港空と大地の歴史館(house,museum,tourism,芝山町,千葉県,日本,289-1608)","成田空港(house,stop,railway,成田市,千葉県,日本,282-0004)","成田空港(house,stop,railway,成田市,千葉県,日本,282-0004)","成田空港(house,stop,railway,成田市,千葉県,日本,282-0004)","成田空港(house,station,railway,成田市,千葉県,日本,282-0004)","成田空港(house,stop,railway,成田市,千葉県,日本,282-0004)","成田空港(house,stop,railway,成田市,千葉県,日本,282-0004)","成田空港検疫所(house,public,building,成田市,千葉県,日本,282-0004)","ナインアワーズ 成田空港店(house,hotel,tourism,成田市,千葉県,日本,282-0004)","成田空港第一ターミナル(house,terminal,aeroway,成田市,千葉県,日本,282-0004)","トヨタレンタカー 成田空港店(house,car_rental,amenity,成田市,千葉県,日本,282-0004)","ニッポンレンタカー 成田空港(house,car_rental,amenity,成田市,千葉県,日本,282-0004)","成田空港駐車場 成田ガレージ(house,parking,amenity,成田市,千葉県,日本,286 0127)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=shizuoka&lang=ja',
  q: 'shizuoka',
  result: '["Shizuoka BMW(house,car,shop,静岡市,駿河区,静岡県,日本,422-8550)","静岡ＳＡ（下り）大型Ｐ(house,parking,amenity,静岡市,葵区,静岡県,日本,420-8602)","静岡ＳＡ（下り）小型Ｐ(house,parking,amenity,静岡市,葵区,静岡県,日本,420-8602)","静岡ＳＡ（上り）大型Ｐ(house,parking,amenity,静岡市,葵区,静岡県,日本,420-8602)","静岡ＳＡ（上り）小型Ｐ(house,parking,amenity,静岡市,葵区,静岡県,日本,420-8602)","Shizuoka Shinbun Shizuoka Hōsō Biru(house,newspaper,office,東京都,中央区,日本,104-0061)","Shizuoka University Library(house,library,amenity,静岡市,駿河区,静岡県,日本,422-8550)","静岡市(city,city,place,静岡県,日本,420-8602)","静岡県(state,province,place,日本)","葵区(district,suburb,place,静岡市,静岡県,日本,420-8602)","静岡(house,station,railway,静岡市,駿河区,静岡県,日本,422-8550)","静岡(house,stop,railway,静岡市,駿河区,静岡県,日本,422-8550)","静岡(house,stop,railway,静岡市,葵区,静岡県,日本,420-8602)","静岡(house,stop,railway,静岡市,葵区,静岡県,日本,420-8602)","静岡(house,stop,railway,静岡市,葵区,静岡県,日本,420-8602)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=shizuoka&lang=en',
  q: 'shizuoka',
  result: '["Shizuoka(city,city,place,Shizuoka Prefecture,Japan,420-8602)","Shizuoka Prefecture(state,province,place,Japan)","Shizuoka(house,stop,railway,Shizuoka,Aoi Ward,Shizuoka Prefecture,Japan,420-8602)","Shizuoka(house,stop,railway,Shizuoka,Aoi Ward,Shizuoka Prefecture,Japan,420-8602)","Shizuoka(house,stop,railway,Shizuoka,Aoi Ward,Shizuoka Prefecture,Japan,420-8602)","Shizuoka(house,station,railway,Shizuoka,Aoi Ward,Shizuoka Prefecture,Japan,420-8602)","Shizuoka(house,station,railway,Shizuoka,Suruga Ward,Shizuoka Prefecture,Japan,422-8550)","Shizuoka(house,stop,railway,Shizuoka,Suruga Ward,Shizuoka Prefecture,Japan,422-8550)","Shizuoka(house,stop,railway,Shizuoka,Aoi Ward,Shizuoka Prefecture,Japan,420-8602)","Shizuoka(house,stop,railway,Shizuoka,Suruga Ward,Shizuoka Prefecture,Japan,422-8550)","Shizuoka Stadium ECOPA(house,stadium,leisure,Fukuroi,Shizuoka Prefecture,Japan,436-0048)","Shin-shizuoka(house,stop,railway,Shizuoka,Aoi Ward,Shizuoka Prefecture,Japan,420-8602)","Shin-shizuoka(house,station,railway,Shizuoka,Aoi Ward,Shizuoka Prefecture,Japan,420-8602)","Shin-shizuoka(house,stop,railway,Shizuoka,Aoi Ward,Shizuoka Prefecture,Japan,420-8602)","Higashi-Shizuoka(house,stop,railway,Shizuoka,Aoi Ward,Shizuoka Prefecture,Japan,420-8602)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E9%9D%99%E5%B2%A1&lang=ja',
  q: '静岡',
  result: '["静岡県(state,province,place,日本)","静岡市(city,city,place,静岡県,日本,420-8602)","静岡(house,stop,railway,静岡市,葵区,静岡県,日本,420-8602)","静岡(house,station,railway,静岡市,葵区,静岡県,日本,420-8602)","静岡(house,station,railway,静岡市,駿河区,静岡県,日本,422-8550)","静岡(house,stop,railway,静岡市,駿河区,静岡県,日本,422-8550)","静岡(house,stop,railway,静岡市,葵区,静岡県,日本,420-8602)","静岡(house,stop,railway,静岡市,葵区,静岡県,日本,420-8602)","静岡(house,stop,railway,静岡市,葵区,静岡県,日本,420-8602)","静岡(house,stop,railway,静岡市,駿河区,静岡県,日本,422-8550)","静岡英和学院大学(house,school,amenity,静岡市,駿河区,静岡県,日本,422-8550)","静岡ＩＣ(house,motorway_junction,highway,静岡市,駿河区,静岡県,日本,422-8550)","静岡文化芸術大学(house,university,amenity,浜松市,中区,静岡県,日本,430-0918)","静岡競輪場(house,stadium,leisure,静岡市,駿河区,静岡県,日本,422-8550)","静岡県立美術館(house,museum,tourism,静岡市,清水区,静岡県,日本,424-8701)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E9%9D%99%E5%B2%A1%E7%9C%8C&lang=ja',
  q: '静岡県',
  result: '["静岡県(state,province,place,日本)","静岡県柑橘試験場落葉果樹分場(locality,commercial,landuse,浜松市,北区,静岡県,日本)","静岡県立浜北西高等学校(house,school,amenity,浜松市,浜北区,静岡県,日本,434-0041)","静岡県企業局都田浄水場(locality,industrial,landuse,浜松市,北区,静岡県,日本)","静岡県警察　静岡南警察署(locality,public,landuse,日本,422-8550)","私立静岡県西遠女子学園(house,school,amenity,浜松市,中区,静岡県,日本,430-0807)","静岡県へようこそ(house,information,tourism,浜松市,西区,静岡県,日本,431-1209)","静岡県へようこそ(house,information,tourism,浜松市,西区,静岡県,日本,431-0211)","静岡県へようこそ(house,information,tourism,伊東市,静岡県,日本,〒413-0231)","静岡県へようこそ(house,information,tourism,浜松市,天竜区,静岡県,日本)","静岡県へようこそ(house,information,tourism,掛川市,静岡県,日本,439-0018)","静岡県へようこそ(house,information,tourism,浜松市,西区,静岡県,日本,431-1209)","静岡県へようこそ(house,information,tourism,浜松市,西区,静岡県,日本,431-0211)","静岡県へようこそ(house,information,tourism,浜松市,西区,静岡県,日本,431-1206)","静岡県へようこそ(house,information,tourism,熱海市,静岡県,日本,413-0102)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E6%9D%BE%E6%9C%AC&lang=ja',
  q: '松本',
  result: '["松本市(city,city,place,長野県,日本)","松本(house,station,railway,松本市,長野県,日本,3900874)","松本(house,station,railway,松本市,長野県,日本,3900874)","松本城(house,castle,historic,松本市,葭町,長野県,日本,390-0874)","松本城(house,museum,tourism,松本市,葭町,長野県,日本,390-0874)","松本大学(house,university,amenity,松本市,新村,長野県,日本,390-1701)","松本空港ターミナルビル(house,terminal,aeroway,松本市,空港東,長野県,日本,3990033)","松本(district,administrative,boundary,青森市,青森県,日本)","松本歯科大学(house,college,amenity,塩尻市,郷原,長野県,日本,399-6461)","松本市美術館(house,museum,tourism,松本市,長野県,日本,390−0815)","松本IC(house,motorway_junction,highway,松本市,長野県,日本,390-0852)","松本(locality,quarter,place,福井市,福井県,日本,910-0003)","松本(locality,neighbourhood,place,球磨村,熊本県,日本)","松本(locality,quarter,place,田原本町,奈良県,日本,636-0213)","松本(locality,quarter,place,沖縄市,沖縄県,日本,904-2155)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E5%93%81%E5%B7%9D%E9%A7%85&lang=ja',
  q: '品川駅',
  result: '["品川駅(house,train_station,building,東京都,品川,日本,108-0075)","品川駅港南商店街(locality,retail,landuse,東京都,品川,日本,108-0075)","品川駅東口(house,bus_stop,highway,東京都,品川,日本,108-0075)","品川駅港南口(house,bus_stop,highway,東京都,品川,日本,108-0075)","品川駅高輪口(house,bus_stop,highway,東京都,品川,日本,108-8611)","品川駅西口(高輪口)(house,bus_stop,highway,東京都,品川,日本,108-8611)","品川駅高輪口(house,bus_station,amenity,東京都,品川,日本,108-8611)","品川駅港南口交番(house,police,amenity,東京都,品川,日本,108-0075)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E6%9D%B1%E4%BA%AC&lang=ja',
  q: '東京',
  result: '["東京都(city,province,place,日本)","東京ドーム(house,stadium,leisure,東京都,文京区,日本,112-0004)","東京(house,station,railway,東京都,千代田区,日本,100-0005)","東京(house,station,railway,東京都,千代田区,日本,100-0005)","東京(house,station,railway,東京都,千代田区,日本,100-0005)","国立国会図書館・東京本館(house,library,amenity,東京都,千代田区,日本,102-0092)","東京湾(locality,bay,natural,日本)","東京国際空港(house,island,man_made,東京都,大田区,日本,144-0041)","東京国際空港(house,aerodrome,aeroway,東京都,大田区,日本,144-0041)","東京タワー(house,tower,man_made,東京都,麻布,日本,105-0011)","東京国際空港(locality,island,place,日本)","東京タワー(house,attraction,tourism,東京都,麻布,日本,105-0011)","東京藝術大学(house,university,amenity,東京都,足立区,日本,120-0034)","東京急行電鉄(house,company,office,東京都,渋谷区,日本,150-8511)","東京競馬場(house,stadium,leisure,東京都,府中市,日本,183-0016)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E6%9D%B1%E4%BA%AC%E9%A7%85&lang=ja',
  q: '東京駅',
  result: '["東京駅(house,bus_stop,highway,東京都,中央区,日本,103-0028)","東京駅(house,bus_stop,highway,東京都,中央区,日本,103-8238)","東京駅(house,bus_stop,highway,東京都,中央区,日本,100-6633)","東京駅中央口(house,traffic_signals,highway,東京都,千代田区,日本,100-0005)","東京駅南口(house,bus_stop,highway,東京都,千代田区,日本,100-0005)","東京駅(house,bus_stop,highway,東京都,千代田区,日本,100-0005)","東京駅南口(house,traffic_signals,highway,東京都,千代田区,日本,100-0005)","東京駅一番街(house,retail,building,東京都,神田,日本,100-0005)","SL 東京駅(house,station,railway,犬山市,愛知県,日本,485-0815)","東京駅 (京葉線)(house,subway_entrance,railway,東京都,千代田区,日本,100-0005)","東京駅 (京葉線)(house,subway_entrance,railway,東京都,千代田区,日本,100-0005)","東京駅丸の内南口(house,bus_stop,highway,東京都,千代田区,日本,100-0005)","東京駅丸の内北口(house,bus_stop,highway,東京都,千代田区,日本,100-0005)","東京駅 (京葉線)(house,subway_entrance,railway,東京都,千代田区,日本,100-0005)","東京駅 (京葉線)(house,subway_entrance,railway,東京都,千代田区,日本,100-0005)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E7%94%A3%E6%A5%AD%E6%8C%AF%E8%88%88%E3%82%BB%E3%83%B3%E3%82%BF%E3%83%BC%20%E5%A4%A7%E9%98%AA&lang=ja',
  q: '産業振興センター 大阪',
  result: '["堺市産業振興センター イベントホール(house,theatre,amenity,堺市,東区,大阪府,日本,540-8570)","寝屋川市立産業振興センター(house,government,office,寝屋川市,大阪府,日本,572-0042)","堺市産業振興センター（じばしん南大阪）第2駐車場(house,parking,amenity,堺市,北区,大阪府,日本,540-8570)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E7%94%A3%E6%A5%AD%E6%8C%AF%E8%88%88%E3%82%BB%E3%83%B3%E3%82%BF%E3%83%BC&lang=ja',
  q: '産業振興センター',
  result: '["産業振興センター(house,stop,railway,横浜市,金沢区,神奈川県,日本,231-0017)","産業振興センター(house,station,railway,横浜市,金沢区,神奈川県,日本,231-0017)","産業振興センター(house,stop,railway,横浜市,金沢区,神奈川県,日本,231-0017)","産業振興センター(house,bus_stop,highway,横浜市,金沢区,神奈川県,日本,231-0017)","産業振興センター(house,community_centre,amenity,東京都,杉並区,日本,167-0051)","産業振興センター(house,company,office,札幌市,白石区,北海道,日本,003-0806)","産業振興センター前(house,bus_stop,highway,新潟市,中央区,新潟県,日本,950-0941)","産業振興センター前(house,traffic_signals,highway,横浜市,金沢区,神奈川県,日本,231-0017)","新潟市産業振興センター(house,public,building,新潟市,中央区,新潟県,日本,950-0941)","産業振興センター診療所(house,doctors,amenity,横浜市,金沢区,神奈川県,日本,231-0017)","堺市産業振興センター イベントホール(house,theatre,amenity,堺市,東区,大阪府,日本,540-8570)","旭川地場産業振興センター(house,yes,building,旭川市,神楽,北海道,日本,070-8004)","神戸市産業振興センター(house,yes,building,神戸市,中央区,兵庫県,日本,650-0044)","名張産業振興センターASPIA(house,yes,office,名張市,三重県,日本,518-0492)","地域産業振興センター前(house,bus_stop,highway,加古川市,兵庫県,日本,675-0057)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E4%BC%8A%E6%9D%B1%E5%B8%82%E9%8E%8C%E7%94%B0&lang=ja',
  q: '伊東市鎌田',
  result: '["伊東鎌田郵便局(house,post_office,amenity,伊東市,静岡県,日本,414-0022)","鎌田幼稚園(house,kindergarten,amenity,伊東市,静岡県,日本,414-0022)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E6%9D%B1%E4%BA%AC%E3%82%BF%E3%83%AF%E3%83%BC&lang=ja',
  q: '東京タワー',
  result: '["東京タワー(house,attraction,tourism,東京都,麻布,日本,105-0011)","東京タワー(house,tower,man_made,東京都,麻布,日本,105-0011)","東京タワー通り(street,tertiary,highway,東京都,麻布,日本,106-0041)","東京タワー通り(street,tertiary,highway,東京都,麻布,日本,105-0011)","東京タワー(house,bus_stop,highway,東京都,麻布,日本,105-0011)","東京タワー前(house,traffic_signals,highway,東京都,麻布,日本,105-0011)","愛宕警察署 東京タワー前交番(house,police,amenity,東京都,麻布,日本,105-0011)","undefined(house,attraction,tourism,東京都,麻布,日本,105-0011)","御成門(house,station,railway,東京都,港区,日本,105-8799)","御成門(house,stop,railway,東京都,港区,日本,105-8799)","御成門(house,stop,railway,東京都,港区,日本,105-8799)","無人宇宙実験システム研究開発機構(house,company,office,東京都,麻布,日本,105-0011)","テレビ東京(house,studio,amenity,東京都,麻布,日本,106-8107)","テレビ東京(house,company,office,東京都,麻布,日本,106-8107)","機械振興会館(house,yes,building,東京都,麻布,日本,105-0011)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E9%8E%8C%E5%80%89%E5%AD%A6%E5%9C%92&lang=ja',
  q: '鎌倉学園',
  result: '["鎌倉学園中・高等学校(house,school,amenity,鎌倉市,台,神奈川県,日本,247-0062)","県立鎌倉高等学校(house,school,amenity,鎌倉市,一丁目,神奈川県,日本,251-0035)","私立鎌倉学園高等学校(house,school,amenity,鎌倉市,台,神奈川県,日本,247-0062)","栄光学園(house,school,amenity,鎌倉市,四丁目,神奈川県,日本,247-0071)","鎌倉市立玉縄小学校(house,school,amenity,鎌倉市,一丁目,神奈川県,日本,247-0072)","県立鎌倉養護学校(house,school,amenity,鎌倉市,関谷,神奈川県,日本,244-0844)","前橋市立 鎌倉中学校(house,school,amenity,前橋市,群馬県,日本,371-0018)","横浜国立大学附属横浜中学校(house,school,amenity,横浜市,南区,神奈川県,日本,231-0017)","私立清泉小学校(house,school,amenity,鎌倉市,三丁目,神奈川県,日本,248-8588)","市立第一小学校(house,school,amenity,鎌倉市,二丁目,神奈川県,日本,248-0014)","県立深沢高等学校(house,school,amenity,鎌倉市,一丁目,神奈川県,日本,251-0015)","神奈川県立柏陽高等学校(house,school,amenity,横浜市,栄区,神奈川県,日本,231-0017)","市立御成小学校(house,school,amenity,鎌倉市,一丁目,神奈川県,日本,248-8686)","横浜市立横浜総合高等学校(house,school,amenity,横浜市,南区,神奈川県,日本,231-0017)","富士見市立西中学校(house,school,amenity,三芳町,埼玉県,日本,354-0043)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E4%BC%8A%E6%9D%B1%20%E3%82%B3%E3%83%B3%E3%83%93%E3%83%8B&lang=ja',
  q: '伊東 コンビニ',
  result: '["セブンイレブン 伊東湯川店(house,convenience,shop,伊東市,静岡県,日本,414-0002)","ローソン(house,convenience,shop,伊東市,静岡県,日本,414-0002)","ローソン(house,convenience,shop,伊東市,静岡県,日本,414-0022)","ローソン(house,convenience,shop,伊東市,静岡県,日本,414-0022)","ファミリーマート(house,convenience,shop,伊東市,静岡県,日本,414-0022)","ファミリーマート(house,convenience,shop,伊東市,静岡県,日本,414-0054)","セブン-イレブン(house,convenience,shop,伊東市,静岡県,日本,414-0002)","ミニストップ(house,convenience,shop,伊東市,静岡県,日本,414-0022)","セブン-イレブン(house,convenience,shop,伊東市,静岡県,日本,414-0002)","ローソン(house,convenience,shop,伊東市,静岡県,日本,413-0232)","ローソン(house,convenience,shop,伊豆市,静岡県,日本,410-2501)","ローソン(house,convenience,shop,伊東市,静岡県,日本,414-0023)","ローソン(house,convenience,shop,伊東市,静岡県,日本,414-0023)","ローソン(house,convenience,shop,伊東市,静岡県,日本,414-0051)","サークルK(house,convenience,shop,伊東市,静岡県,日本,414-0051)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E4%BC%8A%E6%9D%B1%20%E6%B8%A9%E6%B3%89&lang=ja',
  q: '伊東 温泉',
  result: '["立ち寄り温泉;伊東高原の湯(house,parking,amenity,伊東市,静岡県,日本,413-0232)","立ち寄り温泉;伊東高原の湯(house,public_bath,amenity,伊東市,静岡県,日本,413-0232)","富戸温泉(house,public_bath,amenity,伊東市,静岡県,日本,414-0044)","湯ヶ島温泉(house,bus_stop,highway,伊豆市,静岡県,日本,410-3206)","木太刀温泉(house,bus_stop,highway,伊豆市,静岡県,日本,410-3206)","温泉民宿 鈴幸(house,guest_house,tourism,伊東市,静岡県,日本,414-0002)","持越温泉(house,bus_stop,highway,伊豆市,静岡県,日本,410-3206)","宇佐見温泉観光案内図(house,information,tourism,伊東市,静岡県,日本,414-0002)","中伊豆温泉病院(house,hospital,amenity,伊豆市,静岡県,日本,410-2407)","猪戸温泉通りの由来(house,artwork,tourism,伊東市,静岡県,日本,414-0022)","小川温泉共同浴場(house,public_bath,amenity,伊豆市,静岡県,日本,410-2407)","八幡野温泉郷きらの里(house,hotel,tourism,伊東市,静岡県,日本,413-0232)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=414-0054&lang=ja',
  q: '414-0054',
  result: '["城山(locality,peak,natural,日本,414-0054)","落合川(locality,river,waterway,日本,414-0054)","伊東大川(locality,river,waterway,日本,414-0054)","伊東大川(locality,river,waterway,日本,414-0054)","伊東大川(locality,river,waterway,日本,414-0054)","馬場平(locality,volcano,natural,日本,414-0054)","伊東大川(locality,river,waterway,日本,414-0054)","伊東大川(locality,river,waterway,日本,414-0054)","伊東大川(locality,river,waterway,日本,414-0054)","伊東大川(locality,river,waterway,日本,414-0054)","奥野ダム(locality,dam,waterway,日本,414-0054)","冷川峠(locality,yes,mountain_pass,日本,414-0054)","伊東修善寺線(street,primary,highway,伊東市,静岡県,日本,414-0054)","伊東西伊豆線(street,primary,highway,伊東市,静岡県,日本,414-0054)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E9%9D%99%E5%B2%A1%E7%9C%8C%E7%86%B1%E6%B5%B7%E5%B8%82%E7%94%B0%E5%8E%9F%E6%9C%AC%E7%94%BA&lang=ja',
  q: '静岡県熱海市田原本町',
  result: '["熱海(house,stop,railway,熱海市,静岡県,日本,413-0005)","熱海(house,stop,railway,熱海市,静岡県,日本,413-0005)","熱海(house,stop,railway,熱海市,静岡県,日本,413-0005)","熱海(house,stop,railway,熱海市,静岡県,日本,413-0005)","熱海(house,train_station,building,熱海市,静岡県,日本,413-0005)","熱海(house,stop,railway,熱海市,静岡県,日本,413-0005)","熱海(house,station,railway,熱海市,静岡県,日本,413-0005)","熱海(house,stop,railway,熱海市,静岡県,日本,413-0005)","熱海(house,stop,railway,熱海市,静岡県,日本,413-0005)","熱海(house,station,railway,熱海市,静岡県,日本,413-0005)","田原本町(locality,quarter,place,熱海市,静岡県,日本,413-0011)","MOA美術館(house,museum,tourism,熱海市,静岡県,日本,413-8511)","市立桃山小学校(house,school,amenity,熱海市,静岡県,日本,413-0011)","仲見世名店街(street,pedestrian,highway,熱海市,静岡県,日本,413-0011)","平和通り名店街(street,pedestrian,highway,熱海市,静岡県,日本,413-0011)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E7%A5%9E%E5%A5%88%E5%B7%9D%E7%9C%8C%E8%8C%85%E3%83%B6%E5%B4%8E%E5%B8%82&lang=ja',
  q: '神奈川県茅ヶ崎市',
  result: '["茅ヶ崎市(city,city,place,神奈川県,日本)","茅ヶ崎(house,stop,railway,茅ヶ崎市,神奈川県,日本,253-0053)","茅ヶ崎(house,stop,railway,茅ヶ崎市,神奈川県,日本,253-0053)","茅ヶ崎(house,stop,railway,茅ヶ崎市,神奈川県,日本,253-0053)","茅ヶ崎(house,stop,railway,茅ヶ崎市,神奈川県,日本,253-0053)","茅ヶ崎(house,station,railway,茅ヶ崎市,神奈川県,日本,253-0053)","茅ヶ崎(house,stop,railway,茅ヶ崎市,神奈川県,日本,253-0053)","茅ヶ崎(house,stop,railway,茅ヶ崎市,神奈川県,日本,253-0053)","茅ヶ崎(house,station,railway,茅ヶ崎市,神奈川県,日本,253-0053)","モリサイクル(house,motorcycle,shop,茅ヶ崎市,神奈川県,日本,235-0061)","北茅ヶ崎(house,station,railway,茅ヶ崎市,神奈川県,日本,253-8686)","東海道(street,trunk,highway,茅ヶ崎市,神奈川県,日本,2540023)","茅ヶ崎市立病院(house,hospital,amenity,茅ヶ崎市,神奈川県,日本,253-8686)","湘南ジャンクヤード (株)ユーメディアモータース(house,motorcycle,shop,茅ヶ崎市,神奈川県,日本,2540023)","ファミール茅ヶ崎(locality,residential,landuse,茅ヶ崎市,神奈川県,日本)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E3%82%BD%E3%83%8B%E3%83%BC%E3%82%B9%E3%83%88%E3%82%A2%20%E5%A4%A7%E9%98%AA&lang=ja',
  q: 'ソニーストア 大阪',
  result: '["ソニーストア(house,electronics,shop,大阪市,北区,大阪府,日本,530-0001)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E5%8C%97%E5%B2%B3&lang=ja',
  q: '北岳',
  result: '["北岳(locality,peak,natural,日本)","北岳(locality,peak,natural,日本)","北岳(locality,peak,natural,日本)","北岳見晴らし台(locality,locality,place,南アルプス市,山梨県,日本)","北岳肩の小屋(house,alpine_hut,tourism,南アルプス市,山梨県,日本)","北岳の茶屋(house,cafe,amenity,八戸市,青森県,日本,031-0032)","北岳公衆トイレ(house,toilets,amenity,南アルプス市,山梨県,日本)","御岳(locality,peak,natural,日本,892-8677)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E5%A6%99%E9%AB%98%E5%B1%B1&lang=ja',
  q: '妙高山',
  result: '["妙高山(locality,peak,natural,日本)","関山(house,station,railway,妙高市,新潟県,日本)","乙見山峠(locality,locality,place,妙高市,新潟県,日本)","大原関山停車場線(street,secondary,highway,妙高市,新潟県,日本)","大原関山停車場線(street,secondary,highway,妙高市,新潟県,日本)","大原関山停車場線(street,secondary,highway,妙高市,新潟県,日本)","大原関山停車場線(street,secondary,highway,妙高市,新潟県,日本)","大原関山停車場線(street,secondary,highway,妙高市,新潟県,日本)","大原関山停車場線(street,secondary,highway,妙高市,新潟県,日本)","大原関山停車場線(street,secondary,highway,妙高市,新潟県,日本)","大原関山停車場線(street,secondary,highway,妙高市,新潟県,日本)","大原関山停車場線(street,secondary,highway,妙高市,新潟県,日本)","大原関山停車場線(street,secondary,highway,妙高市,新潟県,日本)","大原関山停車場線(street,secondary,highway,妙高市,新潟県,日本)","大原関山停車場線(street,secondary,highway,妙高市,新潟県,日本)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E6%97%A5%E6%9C%AC%E5%A4%A7%E5%AD%A6&lang=ja',
  q: '日本大学',
  result: '["日本大学会館(house,university,building,東京都,千代田区,日本,102-8275)","日本大学高等学校; 日本大学中学校(house,school,amenity,横浜市,港北区,神奈川県,日本,231-0017)","日本大学医学部付属板橋病院(house,hospital,amenity,東京都,板橋区,日本,173-0032)","日本大学 陸上競技場(locality,recreation_ground,landuse,日本,156-0045)","私立 日本大学 第一中学校 第一高等学校(house,school,amenity,東京都,墨田区,日本,130-014)","日本大学鶴ヶ丘高等学校 総合運動場(locality,recreation_ground,landuse,日本)","日本大学山形高等学校 総合運動場(locality,recreation_ground,landuse,日本)","日本大学理工学部御茶ノ水校舎(house,university,amenity,東京都,神田,日本,101-0052)","佐野日本大学短期大学(house,college,amenity,佐野市,栃木県,日本,〒327-0803)","日本大学(house,university,amenity,東京都,世田谷区,日本,156-0045)","日本大学(house,university,amenity,藤沢市,神奈川県,日本,252-0813)","日本大学(house,yes,building,習志野市,千葉県,日本,275-0011)","日本大学(house,university,amenity,東京都,神田,日本,101-0062)","日本大学(house,university,amenity,習志野市,千葉県,日本,275-0011)","日本大学(house,university,building,東京都,世田谷区,日本,154-0002)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E7%9C%8C%E7%AB%8B%E8%8C%85%E3%83%B6%E5%B4%8E%E9%AB%98%E7%AD%89%E5%AD%A6%E6%A0%A1&lang=ja',
  q: '県立茅ヶ崎高等学校',
  result: '["県立茅ヶ崎高等学校(house,school,amenity,茅ヶ崎市,神奈川県,日本,253-0028)","県立茅ヶ崎北陵高等学校(house,school,amenity,茅ヶ崎市,神奈川県,日本,253-0113)","県立茅ヶ崎西浜高等学校(house,school,amenity,茅ヶ崎市,神奈川県,日本,235-0061)","神奈川県立有馬高等学校(house,school,amenity,海老名市,社家,神奈川県,日本,243-0424)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E8%8C%85%E3%83%B6%E5%B4%8E%E9%AB%98%E7%AD%89%E5%AD%A6%E6%A0%A1&lang=ja',
  q: '茅ヶ崎高等学校',
  result: '["県立茅ヶ崎高等学校(house,school,amenity,茅ヶ崎市,神奈川県,日本,253-0028)","県立鶴嶺高等学校(house,school,amenity,茅ヶ崎市,神奈川県,日本,253-8686)","県立茅ヶ崎北陵高等学校(house,school,amenity,茅ヶ崎市,神奈川県,日本,253-0113)","県立茅ヶ崎西浜高等学校(house,school,amenity,茅ヶ崎市,神奈川県,日本,235-0061)","湘南工科大学附属高等学校(house,school,amenity,藤沢市,神奈川県,日本,251-0045)","私立アレセイア湘南高等学校(house,school,amenity,茅ヶ崎市,神奈川県,日本,253-0028)","神奈川県立有馬高等学校(house,school,amenity,海老名市,社家,神奈川県,日本,243-0424)","旧神奈川県立 新磯高等学校(house,school,amenity,座間市,神奈川県,日本,252-0011)","上溝高校入口(house,bus_stop,highway,相模原市,中央区,神奈川県,日本,2520243)","北陵高校入口(house,bus_stop,highway,茅ヶ崎市,神奈川県,日本,253-0113)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E9%9D%99%E5%B2%A1%E7%9C%8C%E4%BC%8A%E6%9D%B1%E5%B8%82&lang=ja',
  q: '静岡県伊東市',
  result: '["伊東市(city,city,place,静岡県,日本)","伊東(house,stop,railway,伊東市,静岡県,日本,414-0002)","パン時館(house,bakery,shop,伊東市,静岡県,日本,〒413-0231)","伊東(house,station,railway,伊東市,静岡県,日本,414-0002)","パン時館(house,bakery,shop,伊東市,静岡県,日本,〒413-0231)","セブンイレブン 伊東湯川店(house,convenience,shop,伊東市,静岡県,日本,414-0002)","伊東(house,stop,railway,伊東市,静岡県,日本,414-0002)","伊東(house,stop,railway,伊東市,静岡県,日本,414-0002)","修善寺(house,stop,railway,伊豆市,静岡県,日本,410-2407)","修善寺(house,station,railway,伊豆市,静岡県,日本,410-2407)","修善寺(house,stop,railway,伊豆市,静岡県,日本,410-2407)","修善寺(house,stop,railway,伊豆市,静岡県,日本,410-2407)","修善寺(house,stop,railway,伊豆市,静岡県,日本,410-2407)","修善寺(house,stop,railway,伊豆市,静岡県,日本,410-2407)","伊豆高原(house,stop,railway,伊東市,静岡県,日本,413-0232)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E9%9D%99%E5%B2%A1%E7%9C%8C%E4%BC%8A%E6%9D%B1%E5%B8%82&lang=ja&lat=33.25625612088059&lon=131.19862044980232&zoom=8',
  q: '静岡県伊東市',
  result: '["伊東市(city,city,place,静岡県,日本)","伊東(house,stop,railway,伊東市,静岡県,日本,414-0002)","パン時館(house,bakery,shop,伊東市,静岡県,日本,〒413-0231)","伊東(house,station,railway,伊東市,静岡県,日本,414-0002)","パン時館(house,bakery,shop,伊東市,静岡県,日本,〒413-0231)","セブンイレブン 伊東湯川店(house,convenience,shop,伊東市,静岡県,日本,414-0002)","伊東(house,stop,railway,伊東市,静岡県,日本,414-0002)","伊東(house,stop,railway,伊東市,静岡県,日本,414-0002)","修善寺(house,stop,railway,伊豆市,静岡県,日本,410-2407)","修善寺(house,station,railway,伊豆市,静岡県,日本,410-2407)","修善寺(house,stop,railway,伊豆市,静岡県,日本,410-2407)","修善寺(house,stop,railway,伊豆市,静岡県,日本,410-2407)","修善寺(house,stop,railway,伊豆市,静岡県,日本,410-2407)","修善寺(house,stop,railway,伊豆市,静岡県,日本,410-2407)","伊豆高原(house,station,railway,伊東市,静岡県,日本,413-0232)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E3%82%BB%E3%83%96%E3%83%B3%E3%82%A4%E3%83%AC%E3%83%96%E3%83%B3&lang=ja&lat=34.96570958880919&lon=139.0937166259622&location_bias_scale=0.1&zoom=14',
  q: 'セブンイレブン',
  result: '["セブンイレブン 伊東湯川店(house,convenience,shop,伊東市,静岡県,日本,414-0002)","セブンイレブン(house,convenience,shop,伊東市,静岡県,日本,414-0051)","セブンイレブン(house,convenience,shop,熱海市,静岡県,日本,〒413-0102)","セブン-イレブン(house,convenience,shop,伊東市,静岡県,日本,414-0012)","セブン-イレブン(house,convenience,shop,伊東市,静岡県,日本,414-0028)","セブン-イレブン(house,convenience,shop,伊東市,静岡県,日本,414-0042)","セブン-イレブン(house,convenience,shop,伊東市,静岡県,日本,414-0002)","セブン-イレブン(house,convenience,shop,伊東市,静岡県,日本,414-0023)","セブン-イレブン(house,convenience,shop,伊東市,静岡県,日本,414-0042)","セブン-イレブン(house,convenience,shop,伊東市,静岡県,日本,414-0051)","セブン-イレブン(house,convenience,shop,伊東市,静岡県,日本,414-0051)","セブン-イレブン(house,convenience,shop,伊東市,静岡県,日本,414-0002)","セブン-イレブン(house,convenience,shop,熱海市,静岡県,日本,〒413-0102)","セブン-イレブン(house,convenience,shop,熱海市,静岡県,日本,〒413-0102)","セブン-イレブン(house,convenience,shop,伊東市,静岡県,日本,413-0232)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E3%82%BB%E3%83%96%E3%83%B3%E3%82%A4%E3%83%AC%E3%83%96%E3%83%B3&lang=ja&lat=34.96570958880919&lon=139.0937166259622&location_bias_scale=0.8&zoom=14',
  q: 'セブンイレブン',
  result: '["セブンイレブン(locality,retail,landuse,いすみ市,千葉県,日本)","セブンイレブン(locality,retail,landuse,和歌山市,和歌山県,日本,640-8511)","セブンイレブン(locality,retail,landuse,和歌山市,和歌山県,日本,640-8511)","セブンイレブン(locality,retail,landuse,伊勢崎市,群馬県,日本)","セブンイレブン(locality,retail,landuse,東京都,渋谷区,日本)","セブンイレブン(locality,retail,landuse,安城市,愛知県,日本)","セブンイレブン(locality,retail,landuse,犬山市,愛知県,日本)","セブンイレブン(locality,retail,landuse,高槻市,大阪府,日本)","セブンイレブン(locality,retail,landuse,和歌山市,和歌山県,日本,640-8511)","セブンイレブン(locality,retail,landuse,酒田市,山形県,日本)","セブンイレブン(locality,retail,landuse,佐野市,栃木県,日本)","セブンイレブン(locality,retail,landuse,犬山市,愛知県,日本)","セブンイレブン(locality,retail,landuse,甲賀市,滋賀県,日本)","セブンイレブン(locality,retail,landuse,越谷市,埼玉県,日本)","セブンイレブン(locality,retail,landuse,東郷町,愛知県,日本)"]'
}
{
  url: 'http://35.221.70.13:2322/api?q=%E6%97%A5%E5%85%89%E6%9D%B1%E7%85%A7%E5%AE%AE&lang=ja',
  q: '日光東照宮',
  result: '["日光東照宮(house,bus_stop,highway,日光市,栃木県,日本,321-1401)","日光東照宮宝物館(house,museum,tourism,日光市,栃木県,日本,321-1401)","東照宮(house,place_of_worship,amenity,日光市,栃木県,日本,321-1401)","東照宮(house,heritage,historic,日光市,栃木県,日本,321-1401)","東照宮美術館(house,museum,tourism,日光市,栃木県,日本,321-1401)","東照宮晃陽苑前(house,bus_stop,highway,日光市,栃木県,日本,３２１１２７３)"]'
}
```

</details>